### PR TITLE
Install clab via install script, override subtopo prefix and add ssh-client

### DIFF
--- a/Dockerfile.launcher
+++ b/Dockerfile.launcher
@@ -31,7 +31,8 @@ RUN apt-get update && \
         vim \
         iproute2 \
         tcpdump \
-        procps
+        procps \
+        openssh-client
 
 RUN echo "deb [trusted=yes] https://apt.fury.io/netdevops/ /" | \
     tee -a /etc/apt/sources.list.d/netdevops.list

--- a/Dockerfile.launcher
+++ b/Dockerfile.launcher
@@ -40,16 +40,19 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | \
     gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
 RUN echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
-        containerlab=0.43.* \
+        # fury repo stopped working, investigating
+        # containerlab=0.44.* \
         docker-ce \
         docker-ce-cli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archive/*.deb
+
+RUN bash -c "$(curl -sL https://get.containerlab.dev)" -- -v 0.44.3
 
 WORKDIR /clabernetes
 COPY --from=builder /clabernetes/build/manager .

--- a/controllers/topology/configmap.go
+++ b/controllers/topology/configmap.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	clabernetesapistopologyv1alpha1 "github.com/srl-labs/clabernetes/apis/topology/v1alpha1"
-	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
+	clabernetesutil "github.com/srl-labs/clabernetes/util"
 	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
 	"gopkg.in/yaml.v3"
 	k8scorev1 "k8s.io/api/core/v1"
@@ -29,11 +29,10 @@ func renderConfigMap(
 	}
 
 	for nodeName, nodeTopo := range clabernetesConfigs {
-		if nodeTopo.Prefix == nil {
-			p := clabernetesconstants.Clabernetes
-
-			nodeTopo.Prefix = &p
-		}
+		// we override existing topo prefix and set it to empty prefix - ""
+		// since prefixes only useful when multiple labs are scheduled on the same node
+		// in clabernetes case, it is always a single node per pod, hence prefix is an obstacle
+		nodeTopo.Prefix = clabernetesutil.StringToPointer("")
 
 		yamlNodeTopo, err := yaml.Marshal(nodeTopo)
 		if err != nil {

--- a/util/pointers.go
+++ b/util/pointers.go
@@ -8,3 +8,6 @@ func Int64ToPointer(i int64) *int64 { return &i }
 
 // BoolToPointer returns a pointer to b.
 func BoolToPointer(b bool) *bool { return &b }
+
+// StringToPointer returns a pointer to s.
+func StringToPointer(s string) *string { return &s }


### PR DESCRIPTION
1. fury apt/yum repo is down for some reason. Opened a ticket. Workaround with script-based install. The drawback of this approach is that sometimes gh throttles requests and concurrent attempts to query its API result in failures that we do not recover from.
2. override subtopo prefix as "" to make it unobstructive when ssh-ing into the container names from the pod
3. added ssh client