### PR TITLE
Rename services

### DIFF
--- a/.develop/devspace.yaml
+++ b/.develop/devspace.yaml
@@ -78,6 +78,14 @@ dev:
 profiles:
   - name: dev
     patches:
+      # replace the image pull policy for dev (but only for init/manager!) to IfNotPresent so that
+      # images loaded into kind are used for those folks that do local dev w/ kind/docker-desktop
+      # w/out this we'd try to pull from ghcr on a tag that doesn't exist. note that this shouldn't
+      # ever be annoying in "dev mode" since we'll already be syncing the code over and the launcher
+      # pull policy is configured independently (see below).
+      - op: replace
+        path: deployments.clabernetes.helm.values.imagePullPolicy
+        value: IfNotPresent
       - op: add
         path: deployments.clabernetes.helm.values.managerLogLevel
         value: debug

--- a/README.md
+++ b/README.md
@@ -9,13 +9,3 @@ containerlab topologies into a kubernetes cluster.
 
 See [clabernetes docs](http://containerlab.dev/manual/clabernetes) for reference.
 
-## TODOs
-
-- Make containerlab writing the deployment log to a file.
-- Add ssh to the clab pods to enable local ssh access to the nodes.
-- Watch docker process in container and restart if there is an issue
-- Be very nice if we cached images maybe at the controller and/or somehow used cluster to pull
-  image rather than having to pull every time container starts
-- Generate kne binding for kne topos (and/or investigate doing that regardless of if topo is kne
-  or not maybe... basically investigate just clab topo -> binding/testbed output so you can run
-  fp tests against any topo)

--- a/controllers/topology/serviceexpose.go
+++ b/controllers/topology/serviceexpose.go
@@ -281,7 +281,7 @@ func (r *Reconciler) renderExposeService(
 		UDPPorts: make([]int, 0),
 	}
 
-	serviceName := fmt.Sprintf("%s-%s-expose", name, nodeName)
+	serviceName := fmt.Sprintf("%s-%s", name, nodeName)
 
 	labels := map[string]string{
 		clabernetesconstants.LabelApp:                 clabernetesconstants.Clabernetes,

--- a/controllers/topology/servicefabric.go
+++ b/controllers/topology/servicefabric.go
@@ -76,7 +76,7 @@ func (r *Reconciler) resolveFabricServices(
 	var nodeIdx int
 
 	for nodeName := range clabernetesConfigs {
-		allNodes[nodeIdx] = nodeName
+		allNodes[nodeIdx] = fmt.Sprintf("%s-%s", nodeName, "vx")
 
 		nodeIdx++
 	}


### PR DESCRIPTION
This pr fixes #6 
it produces the following output on a quickstart example:


```
❯ k get svc -n srl02
NAME                 TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                                                                                                                                                                   AGE
clab-srl02-srl1      LoadBalancer   10.96.130.76    172.18.1.10   161:31968/UDP,21:32230/TCP,22:30722/TCP,23:32329/TCP,80:31708/TCP,443:30392/TCP,830:30954/TCP,5000:30852/TCP,5900:30031/TCP,6030:31250/TCP,9339:32620/TCP,9340:30104/TCP,9559:32624/TCP,57400:30806/TCP   39s
clab-srl02-srl1-vx   ClusterIP      10.96.198.42    <none>        4789/UDP                                                                                                                                                                                                  40s
clab-srl02-srl2      LoadBalancer   10.96.227.153   172.18.1.11   161:32330/UDP,21:31274/TCP,22:31321/TCP,23:31466/TCP,80:30947/TCP,443:32154/TCP,830:32300/TCP,5000:30241/TCP,5900:30688/TCP,6030:30977/TCP,9339:30847/TCP,9340:32687/TCP,9559:31699/TCP,57400:32644/TCP   39s
clab-srl02-srl2-vx   ClusterIP      10.96.161.133   <none>        4789/UDP
```