### PR TITLE
Fixing service renaming

### DIFF
--- a/controllers/topology/containerlab/config.go
+++ b/controllers/topology/containerlab/config.go
@@ -406,7 +406,7 @@ func (c *Controller) processConfig( //nolint:funlen,gocyclo
 					LocalNodeName:  nodeName,
 					RemoteNodeName: uninterestingEndpoint.NodeName,
 					RemoteName: fmt.Sprintf(
-						"%s-%s.%s.svc.cluster.local",
+						"%s-%s-vx.%s.svc.cluster.local",
 						clab.Name,
 						uninterestingEndpoint.NodeName,
 						clab.Namespace,

--- a/controllers/topology/servicefabric.go
+++ b/controllers/topology/servicefabric.go
@@ -76,7 +76,7 @@ func (r *Reconciler) resolveFabricServices(
 	var nodeIdx int
 
 	for nodeName := range clabernetesConfigs {
-		allNodes[nodeIdx] = fmt.Sprintf("%s-%s", nodeName, "vx")
+		allNodes[nodeIdx] = nodeName
 
 		nodeIdx++
 	}
@@ -227,7 +227,7 @@ func renderFabricService(
 ) *k8scorev1.Service {
 	name := obj.GetName()
 
-	serviceName := fmt.Sprintf("%s-%s", name, nodeName)
+	serviceName := fmt.Sprintf("%s-%s-vx", name, nodeName)
 
 	labels := map[string]string{
 		clabernetesconstants.LabelApp:                 clabernetesconstants.Clabernetes,


### PR DESCRIPTION
@carlmontanari I screwed up vxlan tunneling with #16 
The tunnels.yml used service name without `-vx` suffix that was added. I added it in this PR but it still flaky, because somehow the clusterIP services now use the obj.Name as `srl1-vx` and not just `srl1`.

This screws service selectors:

```yaml
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2023-09-20T10:09:46Z"
  labels:
    clabernetes/app: clabernetes
    clabernetes/name: clab-srl02-srl2-vx
    clabernetes/topologyNode: srl2-vx
    clabernetes/topologyOwner: clab-srl02
    clabernetes/topologyServiceType: fabric
  name: clab-srl02-srl2-vx
  namespace: srl02
  ownerReferences:
  - apiVersion: topology.clabernetes/v1alpha1
    kind: Containerlab
    name: clab-srl02
    uid: 136a9911-841f-4dc3-8050-3bd9e15fd493
  resourceVersion: "244739"
  uid: 3be44f91-9282-4886-940c-87d0ecc14dbe
spec:
  clusterIP: 10.96.77.24
  clusterIPs:
  - 10.96.77.24
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: vxlan
    port: 4789
    protocol: UDP
    targetPort: 4789
  selector:
    clabernetes/topologyNode: srl2-vx
    clabernetes/topologyOwner: clab-srl02
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

I am a bit lost here. Why the obj name here now `srl1-vx`? And how to make it better?

https://github.com/srl-labs/clabernetes/blob/cf4774a3551f52b5fcd4cb8809ecb03452671ef7/controllers/topology/servicefabric.go#L228