### PR TITLE
Feat/clab license support

### DIFF
--- a/.develop/devspace.yaml
+++ b/.develop/devspace.yaml
@@ -178,6 +178,14 @@ pipelines:
     run: |
       build_images clabernetes clabernetes-launcher clabverter
 
+  dev:
+    # override the default dev pipeline to not bother building clabverter while doing dev things
+    run: |
+      ensure_pull_secrets --all
+      build_images clabernetes-dev clabernetes clabernetes-launcher
+      create_deployments --all
+      start_dev --all
+
   purge:
     run: |-
       stop_dev --all

--- a/clabverter/assets/containerlab.yaml.template
+++ b/clabverter/assets/containerlab.yaml.template
@@ -11,7 +11,7 @@ spec:
     - {{ $registry }}
     {{- end }}
   {{- end }}
-  {{- if gt (len .StartupConfigs) 0 }}
+  {{- if or (gt (len .StartupConfigs) 0) (gt (len .ExtraFiles) 0) }}
   filesFromConfigMap:
     {{- range $startupConfigData := .StartupConfigs }}
       - nodeName: {{ $startupConfigData.NodeName }}
@@ -19,6 +19,13 @@ spec:
         configMapName: {{ $startupConfigData.ConfigMapName }}
         configMapPath: startup-config
     {{- end }}
+    {{- range $extraFileData := .ExtraFiles }}
+      - nodeName: {{ $extraFileData.NodeName }}
+        filePath: {{ $extraFileData.FilePath }}
+        configMapName: {{ $extraFileData.ConfigMapName }}
+        configMapPath: {{ $extraFileData.FileName }}
+    {{- end }}
   {{- end }}
+
   config: |-
     {{- .ClabConfig }}

--- a/clabverter/assets/files-configmap.yaml.template
+++ b/clabverter/assets/files-configmap.yaml.template
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Name }}
+  namespace:  {{ .Namespace }}
+data:
+{{- range $fileName, $fileContents := .ExtraFiles }}
+  {{ $fileName }}: |-
+    {{- $fileContents }}
+{{- end }}

--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -18,16 +18,23 @@ import (
 
 const specIndentSpaces = 4
 
-type configMapTemplateVars struct {
+type startupConfigConfigMapTemplateVars struct {
 	Name          string
 	Namespace     string
 	StartupConfig string
+}
+
+type extraFilesConfigMapTemplateVars struct {
+	Name       string
+	Namespace  string
+	ExtraFiles map[string]string
 }
 
 type topologyConfigMapTemplateVars struct {
 	NodeName      string
 	ConfigMapName string
 	FilePath      string
+	FileName      string
 }
 
 type containerlabTemplateVars struct {
@@ -35,7 +42,40 @@ type containerlabTemplateVars struct {
 	Namespace          string
 	ClabConfig         string
 	StartupConfigs     []topologyConfigMapTemplateVars
+	ExtraFiles         []topologyConfigMapTemplateVars
 	InsecureRegistries []string
+}
+
+type renderedContent struct {
+	friendlyName string
+	fileName     string
+	content      []byte
+}
+
+func getExtraFilesForNode(
+	clabConfig *clabernetesutilcontainerlab.Config,
+	nodeName string,
+) ([]string, error) {
+	var paths []string
+
+	nodeConfig, ok := clabConfig.Topology.Nodes[nodeName]
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: issue fetching extra files for node '%s', this is a bug",
+			ErrClabvert,
+			nodeName,
+		)
+	}
+
+	if nodeConfig.License != "" {
+		paths = append(paths, nodeConfig.License)
+	} else if clabConfig.Topology.Defaults != nil && clabConfig.Topology.Defaults.License != "" {
+		paths = append(paths, clabConfig.Topology.Defaults.License)
+	}
+
+	// if there are other files we need to try to load we can just put them here
+
+	return paths, nil
 }
 
 // MustNewClabverter returns an instance of Clabverter or panics.
@@ -73,6 +113,8 @@ func MustNewClabverter(
 		destinationNamespace:    destinationNamespace,
 		insecureRegistries:      strings.Split(insecureRegistries, ","),
 		startupConfigConfigMaps: make(map[string]topologyConfigMapTemplateVars),
+		extraFilesConfigMaps:    make(map[string][]topologyConfigMapTemplateVars),
+		renderedFiles:           []renderedContent{},
 	}
 }
 
@@ -96,8 +138,17 @@ type Clabverter struct {
 	rawClabConfig string
 	clabConfig    *clabernetesutilcontainerlab.Config
 
-	// mapping of nodeName -> startup-config info for the templating process
+	// mapping of nodeName -> startup-config info for the templating process; this is its own thing
+	// because configurations may be huge and configmaps have a 1M char limit, so while keeping them
+	// by themselves may not "solve" for ginormous configs, it can certainly give us a little extra
+	// breathing room by not having other data in the startup configmap.
 	startupConfigConfigMaps map[string]topologyConfigMapTemplateVars
+
+	// all other config files associated to the node(s) -- for example license file(s).
+	extraFilesConfigMaps map[string][]topologyConfigMapTemplateVars
+
+	// filenames -> content of all rendered files we need to either print to stdout or write to disk
+	renderedFiles []renderedContent
 }
 
 // Clabvert is the main (only) entrypoint that kicks off the "clabversion" process.
@@ -114,12 +165,17 @@ func (c *Clabverter) Clabvert() error {
 		return err
 	}
 
-	err = c.handleStartupConfigs()
+	err = c.handleAssociatedFiles()
 	if err != nil {
 		return err
 	}
 
 	err = c.handleManifest()
+	if err != nil {
+		return err
+	}
+
+	err = c.output()
 	if err != nil {
 		return err
 	}
@@ -147,6 +203,29 @@ func (c *Clabverter) ensureOutputDirectory() error {
 	}
 
 	return nil
+}
+
+func (c *Clabverter) resolveContentAtPath(path string) ([]byte, error) {
+	var content []byte
+
+	var err error
+
+	switch {
+	case isURL(c.topologyFile):
+		content, err = loadContentAtURL(
+			fmt.Sprintf("%s/%s", c.topologyPathParent, path),
+		)
+	default:
+		fullyQualifiedStartupConfigPath := fmt.Sprintf(
+			"%s/%s",
+			c.topologyPathParent,
+			path,
+		)
+
+		content, err = os.ReadFile(fullyQualifiedStartupConfigPath) //nolint:gosec
+	}
+
+	return content, err
 }
 
 func (c *Clabverter) load() error {
@@ -229,10 +308,27 @@ func (c *Clabverter) load() error {
 	return nil
 }
 
+func (c *Clabverter) handleAssociatedFiles() error {
+	c.logger.Info("handling containerlab associated file(s) if present...")
+
+	err := c.handleStartupConfigs()
+	if err != nil {
+		return err
+	}
+
+	err = c.handleExtraFiles()
+	if err != nil {
+		return err
+	}
+
+	c.logger.Debug("handling associated file(s) complete")
+
+	return nil
+}
+
 func (c *Clabverter) handleStartupConfigs() error {
 	c.logger.Info("handling containerlab topology startup config(s) if present...")
 
-	// determine if any startup configs exist (probably other stuff but at least this?)
 	startupConfigs := map[string][]byte{}
 
 	for nodeName, nodeData := range c.clabConfig.Topology.Nodes {
@@ -244,25 +340,7 @@ func (c *Clabverter) handleStartupConfigs() error {
 
 		c.logger.Debugf("loading node '%s' startup-config...", nodeName)
 
-		var startupConfigContents []byte
-
-		var err error
-
-		switch {
-		case isURL(c.topologyFile):
-			startupConfigContents, err = loadContentAtURL(
-				fmt.Sprintf("%s/%s", c.topologyPathParent, nodeData.StartupConfig),
-			)
-		default:
-			fullyQualifiedStartupConfigPath := fmt.Sprintf(
-				"%s/%s",
-				c.topologyPathParent,
-				nodeData.StartupConfig,
-			)
-
-			startupConfigContents, err = os.ReadFile(fullyQualifiedStartupConfigPath) //nolint:gosec
-		}
-
+		startupConfigContents, err := c.resolveContentAtPath(nodeData.StartupConfig)
 		if err != nil {
 			c.logger.Criticalf(
 				"failed loading startup-config contents for node '%s', error: %s",
@@ -282,7 +360,10 @@ func (c *Clabverter) handleStartupConfigs() error {
 	for nodeName, startupConfigContents := range startupConfigs {
 		t, err := template.ParseFS(Assets, "assets/startup-config-configmap.yaml.template")
 		if err != nil {
-			c.logger.Criticalf("failed loading configmap template from assets: %s", err)
+			c.logger.Criticalf(
+				"failed loading startup-config configmap template from assets: %s",
+				err,
+			)
 
 			return err
 		}
@@ -293,7 +374,7 @@ func (c *Clabverter) handleStartupConfigs() error {
 
 		err = t.Execute(
 			&rendered,
-			configMapTemplateVars{
+			startupConfigConfigMapTemplateVars{
 				Name:      configMapName,
 				Namespace: c.destinationNamespace,
 				// pad w/ a newline so the template can look prettier :)
@@ -309,31 +390,16 @@ func (c *Clabverter) handleStartupConfigs() error {
 			return err
 		}
 
-		if c.stdout {
-			_, err = os.Stdout.Write(rendered.Bytes())
-			if err != nil {
-				c.logger.Criticalf(
-					"failed writing node '%s' startup config to stdout: %s", nodeName, err,
-				)
+		fileName := fmt.Sprintf("%s/%s-startup-config.yaml", c.outputDirectory, nodeName)
 
-				return err
-			}
-		} else {
-			err = os.WriteFile(
-				fmt.Sprintf("%s/%s-startup-config.yaml", c.outputDirectory, nodeName),
-				rendered.Bytes(),
-				clabernetesconstants.PermissionsEveryoneRead,
-			)
-			if err != nil {
-				c.logger.Criticalf(
-					"failed writing node '%s' startup config to output directory: %s",
-					nodeName,
-					err,
-				)
-
-				return err
-			}
-		}
+		c.renderedFiles = append(
+			c.renderedFiles,
+			renderedContent{
+				friendlyName: fmt.Sprintf("%s-statup-config", nodeName),
+				fileName:     fileName,
+				content:      rendered.Bytes(),
+			},
+		)
 
 		c.startupConfigConfigMaps[nodeName] = topologyConfigMapTemplateVars{
 			NodeName:      nodeName,
@@ -343,6 +409,114 @@ func (c *Clabverter) handleStartupConfigs() error {
 	}
 
 	c.logger.Debug("handling startup configs complete")
+
+	return nil
+}
+
+func (c *Clabverter) handleExtraFiles() error {
+	c.logger.Info("handling containerlab extra file(s) if present...")
+
+	extraFiles := make(map[string]map[string][]byte)
+
+	for nodeName := range c.clabConfig.Topology.Nodes {
+		extraFilePaths, err := getExtraFilesForNode(c.clabConfig, nodeName)
+		if err != nil {
+			c.logger.Criticalf(
+				"failed determining extra file paths for node '%s', error: %s",
+				nodeName,
+				err,
+			)
+
+			return err
+		}
+
+		if len(extraFilePaths) == 0 {
+			continue
+		}
+
+		extraFiles[nodeName] = make(map[string][]byte)
+
+		for _, extraFilePath := range extraFilePaths {
+			c.logger.Debugf("loading node '%s' extra file '%s'...", nodeName, extraFilePath)
+
+			var extraFileContent []byte
+
+			extraFileContent, err = c.resolveContentAtPath(extraFilePath)
+			if err != nil {
+				c.logger.Criticalf(
+					"failed loading extra file '%s' contents for node '%s', error: %s",
+					extraFilePath,
+					nodeName,
+					err,
+				)
+
+				return err
+			}
+
+			extraFiles[nodeName][strings.ReplaceAll(extraFilePath, "/", "_")] = extraFileContent
+		}
+	}
+
+	c.logger.Info("rendering clabernetes extra file(s) outputs...")
+
+	// render "extra" files
+	for nodeName, nodeExtraFiles := range extraFiles {
+		t, err := template.ParseFS(Assets, "assets/files-configmap.yaml.template")
+		if err != nil {
+			c.logger.Criticalf("failed loading files configmap template from assets: %s", err)
+
+			return err
+		}
+
+		configMapName := fmt.Sprintf("%s-%s-files", c.clabConfig.Name, nodeName)
+
+		templateVars := extraFilesConfigMapTemplateVars{
+			Name:       configMapName,
+			Namespace:  c.destinationNamespace,
+			ExtraFiles: make(map[string]string),
+		}
+
+		c.extraFilesConfigMaps[nodeName] = make([]topologyConfigMapTemplateVars, 0)
+
+		for extraFileName, extraFileContent := range nodeExtraFiles {
+			templateVars.ExtraFiles[extraFileName] = "\n" + clabernetesutil.Indent(
+				string(extraFileContent),
+				specIndentSpaces,
+			)
+
+			c.extraFilesConfigMaps[nodeName] = append(
+				c.extraFilesConfigMaps[nodeName],
+				topologyConfigMapTemplateVars{
+					NodeName:      nodeName,
+					ConfigMapName: configMapName,
+					FilePath:      extraFileName,
+					FileName:      extraFileName,
+				},
+			)
+		}
+
+		var rendered bytes.Buffer
+
+		err = t.Execute(&rendered, templateVars)
+		if err != nil {
+			c.logger.Criticalf("failed executing configmap template: %s", err)
+
+			return err
+		}
+
+		fileName := fmt.Sprintf("%s/%s-extra-files.yaml", c.outputDirectory, nodeName)
+
+		c.renderedFiles = append(
+			c.renderedFiles,
+			renderedContent{
+				friendlyName: fmt.Sprintf("%s-statup-config", nodeName),
+				fileName:     fileName,
+				content:      rendered.Bytes(),
+			},
+		)
+	}
+
+	c.logger.Debug("handling extra file(s) complete")
 
 	return nil
 }
@@ -357,12 +531,18 @@ func (c *Clabverter) handleManifest() error {
 
 	startupConfigs := make([]topologyConfigMapTemplateVars, len(c.startupConfigConfigMaps))
 
-	var idx int
+	var startupConfigsIdx int
 
 	for _, startupConfig := range c.startupConfigConfigMaps {
-		startupConfigs[idx] = startupConfig
+		startupConfigs[startupConfigsIdx] = startupConfig
 
-		idx++
+		startupConfigsIdx++
+	}
+
+	extraFiles := make([]topologyConfigMapTemplateVars, 0)
+
+	for _, nodeExtraFiles := range c.extraFilesConfigMaps {
+		extraFiles = append(extraFiles, nodeExtraFiles...)
 	}
 
 	var rendered bytes.Buffer
@@ -375,6 +555,7 @@ func (c *Clabverter) handleManifest() error {
 			// pad w/ a newline so the template can look prettier :)
 			ClabConfig:         "\n" + clabernetesutil.Indent(c.rawClabConfig, specIndentSpaces),
 			StartupConfigs:     startupConfigs,
+			ExtraFiles:         extraFiles,
 			InsecureRegistries: c.insecureRegistries,
 		},
 	)
@@ -384,27 +565,46 @@ func (c *Clabverter) handleManifest() error {
 		return err
 	}
 
-	if c.stdout {
-		_, err = os.Stdout.Write(rendered.Bytes())
-		if err != nil {
-			c.logger.Criticalf(
-				"failed writing containerlab manifest to stdout: %s", err,
-			)
+	fileName := fmt.Sprintf("%s/%s.yaml", c.outputDirectory, c.clabConfig.Name)
 
-			return err
-		}
-	} else {
-		err = os.WriteFile(
-			fmt.Sprintf("%s/%s.yaml", c.outputDirectory, c.clabConfig.Name),
-			rendered.Bytes(),
-			clabernetesconstants.PermissionsEveryoneRead,
-		)
-		if err != nil {
-			c.logger.Criticalf(
-				"failed writing containerlab manifest to output directory: %s", err,
-			)
+	c.renderedFiles = append(
+		c.renderedFiles,
+		renderedContent{
+			friendlyName: "clabernetes manifest",
+			fileName:     fileName,
+			content:      rendered.Bytes(),
+		},
+	)
 
-			return err
+	return nil
+}
+
+func (c *Clabverter) output() error {
+	for _, rendered := range c.renderedFiles {
+		if c.stdout {
+			_, err := os.Stdout.Write(rendered.content)
+			if err != nil {
+				c.logger.Criticalf(
+					"failed writing '%s' startup config to stdout: %s", rendered.friendlyName, err,
+				)
+
+				return err
+			}
+		} else {
+			err := os.WriteFile(
+				rendered.fileName,
+				rendered.content,
+				clabernetesconstants.PermissionsEveryoneRead,
+			)
+			if err != nil {
+				c.logger.Criticalf(
+					"failed writing '%s' to output directory: %s",
+					rendered.friendlyName,
+					err,
+				)
+
+				return err
+			}
 		}
 	}
 

--- a/clabverter/error.go
+++ b/clabverter/error.go
@@ -1,0 +1,6 @@
+package clabverter
+
+import "errors"
+
+// ErrClabvert is the error returned when encountering issues with the clabversion process.
+var ErrClabvert = errors.New("errClabvert")

--- a/clabverter/util.go
+++ b/clabverter/util.go
@@ -22,6 +22,15 @@ func loadContentAtURL(path string) ([]byte, error) {
 
 	defer resp.Body.Close() //nolint
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"%w: non 200 status attempting to load content at '%s', status code: %d",
+			ErrClabvert,
+			path,
+			resp.StatusCode,
+		)
+	}
+
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/controllers/topology/configmap.go
+++ b/controllers/topology/configmap.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 
 	clabernetesapistopologyv1alpha1 "github.com/srl-labs/clabernetes/apis/topology/v1alpha1"
-	clabernetesutil "github.com/srl-labs/clabernetes/util"
 	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
 	"gopkg.in/yaml.v3"
 	k8scorev1 "k8s.io/api/core/v1"
@@ -29,11 +28,6 @@ func renderConfigMap(
 	}
 
 	for nodeName, nodeTopo := range clabernetesConfigs {
-		// we override existing topo prefix and set it to empty prefix - ""
-		// since prefixes only useful when multiple labs are scheduled on the same node
-		// in clabernetes case, it is always a single node per pod, hence prefix is an obstacle
-		nodeTopo.Prefix = clabernetesutil.StringToPointer("")
-
 		yamlNodeTopo, err := yaml.Marshal(nodeTopo)
 		if err != nil {
 			return nil, err

--- a/controllers/topology/containerlab/config.go
+++ b/controllers/topology/containerlab/config.go
@@ -317,6 +317,11 @@ func (c *Controller) processConfig( //nolint:funlen,gocyclo
 				},
 				Links: nil,
 			},
+			// we override existing topo prefix and set it to empty prefix - "" (rather than accept
+			// what the user has provided *or* the default of "clab").
+			// since prefixes are only useful when multiple labs are scheduled on the same node, and
+			// that will never be the case with clabernetes, the prefix is unnecessary.
+			Prefix: clabernetesutil.StringToPointer(""),
 		}
 
 		for _, link := range clabTopo.Links {

--- a/controllers/topology/kne/config.go
+++ b/controllers/topology/kne/config.go
@@ -82,6 +82,7 @@ func (c *Controller) processConfig( //nolint:funlen
 				},
 				Links: nil,
 			},
+			Prefix: clabernetesutil.StringToPointer(""),
 		}
 
 		if kneModel != "" {


### PR DESCRIPTION
cc @hellt 

important note: startup configs could be ginormous (potentially), so keeping them in their own configmap as configmap has 1m char limit (etcd limit). 

currently this does not handle pointing to files in non-top adjacent dirs well -- we replace `/` with `_` at the moment so that configmap data keys are valid. can/should fix this (also for startup configs) so that we dont have to do even more manipulation to clab "sub" topos.

could maybe do one key with the replaced file name (ex: file name "sometihng/license.txt" -> "something_license.txt") with the data in that key, then a second key "something_license.txt_path" where the key of this second thing is the actual path we should set when mounting configmap. I dunno. im sleepy now... for future me/us to consider better :)


testing this w/ a clab topo like:

```yaml
name: srl02

topology:
  nodes:
    srl1:
      kind: srl
      image: ghcr.io/nokia/srlinux
      startup-config: srl1.cfg
      license: taco/srl1.license
    srl2:
      kind: srl
      image: ghcr.io/nokia/srlinux
      startup-config: srl2.cfg
      license: srl2.license

  links:
    - endpoints: ["srl1:e1-1", "srl2:e1-1"]
```

`go run cmd/clabverter/main.go --topologyFile .clabversiontest/clab.yaml --debug --stdout` if you wanna check output 

or `--outputDirectory foo/` to dump to disk...

or something like `go run cmd/clabverter/main.go --topologyFile .clabversiontest/clab.yaml  --stdout --quiet | kubectl delete -f -` to just yolo it into cluster if you're feeling frisky.