### PR TITLE
refactor: better log setup, esp for clabverter where we default to stderr now

### DIFF
--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -98,6 +98,10 @@ func MustNewClabverter(
 		logLevel = clabernetesconstants.Disabled
 	}
 
+	claberneteslogging.InitManager(
+		claberneteslogging.WithLogger(claberneteslogging.StdErrLog),
+	)
+
 	logManager := claberneteslogging.GetManager()
 
 	clabverterLogger := logManager.MustRegisterAndGetLogger(
@@ -634,7 +638,10 @@ func (c *Clabverter) findClabFile() error {
 	}
 
 	if len(files) != 1 {
-		return fmt.Errorf("%w: none or more than one topology files found, can't auto select one", ErrClabvert)
+		return fmt.Errorf(
+			"%w: none or more than one topology files found, can't auto select one",
+			ErrClabvert,
+		)
 	}
 
 	c.logger.Infof("found topology file %q", files[0])

--- a/controllers/base.go
+++ b/controllers/base.go
@@ -36,9 +36,9 @@ func NewBaseController(
 	config *clientgorest.Config,
 	client ctrlruntimeclient.Client,
 ) *BaseController {
-	lm := claberneteslogging.GetManager()
+	logManager := claberneteslogging.GetManager()
 
-	logger := lm.MustRegisterAndGetLogger(
+	logger := logManager.MustRegisterAndGetLogger(
 		controllerName,
 		clabernetesutil.GetEnvStrOrDefault(
 			clabernetesconstants.ControllerLoggerLevelEnv,

--- a/logging/loggers.go
+++ b/logging/loggers.go
@@ -1,0 +1,16 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+)
+
+// the default and very simple logger.
+func printLog(a ...any) {
+	fmt.Println(a...) //nolint:forbidigo
+}
+
+// StdErrLog writes `a` to stderr, it ignores failures.
+func StdErrLog(a ...any) {
+	_, _ = fmt.Fprintln(os.Stderr, a...)
+}

--- a/logging/manager.go
+++ b/logging/manager.go
@@ -26,7 +26,7 @@ func InitManager(options ...Option) {
 			formatter:       DefaultFormatter,
 			instances:       map[string]*instance{},
 			instanceCancels: map[string]context.CancelFunc{},
-			loggers:         []func(...interface{}){},
+			loggers:         []func(...any){},
 		}
 
 		for _, option := range options {

--- a/logging/manager.go
+++ b/logging/manager.go
@@ -17,20 +17,39 @@ const (
 	flushWaitSleep    = 25 * time.Millisecond
 )
 
-func printLog(a ...any) {
-	fmt.Println(a...) //nolint:forbidigo
-}
-
-// GetManager returns the global logging Manager.
-func GetManager() Manager {
+// InitManager initializes the logging manager with the provided options. It does nothing if the
+// manager has already been initialized. This may be a bit awkward but since this is not expected
+// to be used by anything but clabernetes and it works for us, it works!
+func InitManager(options ...Option) {
 	managerInstanceOnce.Do(func() {
-		managerInstance = &manager{
+		m := &manager{
 			formatter:       DefaultFormatter,
 			instances:       map[string]*instance{},
 			instanceCancels: map[string]context.CancelFunc{},
-			loggers:         []func(...interface{}){printLog},
+			loggers:         []func(...interface{}){},
 		}
+
+		for _, option := range options {
+			option(m)
+		}
+
+		if len(m.loggers) == 0 {
+			m.loggers = []func(...interface{}){printLog}
+		}
+
+		managerInstance = m
 	})
+}
+
+// GetManager returns the global logging Manager. Panics if the logging manager has *not* been
+// initialized (via InitManager).
+func GetManager() Manager {
+	if managerInstance == nil {
+		panic(
+			"Manager instance is nil, 'GetManager' should never be called until the manager " +
+				"process has been started",
+		)
+	}
 
 	return managerInstance
 }

--- a/logging/options.go
+++ b/logging/options.go
@@ -1,0 +1,12 @@
+package logging
+
+// Option is a functional option type for applying options to the logging Manager.
+type Option func(m *manager)
+
+// WithLogger appends a logger (a function that accepts an interface) to the logging Manager's set
+// of loggers.
+func WithLogger(logger func(...interface{})) Option {
+	return func(m *manager) {
+		m.loggers = append(m.loggers, logger)
+	}
+}

--- a/manager/clabernetes.go
+++ b/manager/clabernetes.go
@@ -32,6 +32,8 @@ func StartClabernetes(initializer bool) {
 
 	rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 
+	claberneteslogging.InitManager()
+
 	logManager := claberneteslogging.GetManager()
 
 	clabernetesLogger := logManager.MustRegisterAndGetLogger(

--- a/manager/start.go
+++ b/manager/start.go
@@ -143,9 +143,7 @@ func (c *clabernetes) start(ctx context.Context) {
 }
 
 func (c *clabernetes) exit(exitCode int) {
-	loggingManager := claberneteslogging.GetManager()
-
-	loggingManager.Flush()
+	claberneteslogging.GetManager().Flush()
 
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
bit awkward but we now have an "InitManager" -- since this is just an internal thing and we only have to init the manager in like two places this feels "ok". now on init we can pass options to the logging manager -- for this specific thing we pass the logger that emits to stderr rather than stdout. in the future we can specify log formatters and stuff easily now too.