### PR TITLE
feat: add /dev/kvm mount

### DIFF
--- a/controllers/topology/reconciler/deployment.go
+++ b/controllers/topology/reconciler/deployment.go
@@ -522,6 +522,14 @@ func (r *DeploymentReconciler) renderDeploymentDevices(
 		deployment.Spec.Template.Spec.Volumes,
 		[]k8scorev1.Volume{
 			{
+				Name: "dev-kvm",
+				VolumeSource: k8scorev1.VolumeSource{
+					HostPath: &k8scorev1.HostPathVolumeSource{
+						Path: "/dev/kvm",
+					},
+				},
+			},
+			{
 				Name: "dev-fuse",
 				VolumeSource: k8scorev1.VolumeSource{
 					HostPath: &k8scorev1.HostPathVolumeSource{
@@ -544,6 +552,11 @@ func (r *DeploymentReconciler) renderDeploymentDevices(
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
 		[]k8scorev1.VolumeMount{
+			{
+				Name:      "dev-kvm",
+				ReadOnly:  true,
+				MountPath: "/dev/kvm",
+			},
 			{
 				Name:      "dev-fuse",
 				ReadOnly:  true,

--- a/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/containerlab-debug.json
+++ b/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/containerlab-debug.json
@@ -47,6 +47,12 @@
                         }
                     },
                     {
+                        "name": "dev-kvm",
+                        "hostPath": {
+                            "path": "/dev/kvm"
+                        }
+                    },
+                    {
                         "name": "dev-fuse",
                         "hostPath": {
                             "path": "/dev/fuse"
@@ -118,6 +124,11 @@
                                 "readOnly": true,
                                 "mountPath": "/clabernetes/files-from-url.yaml",
                                 "subPath": "srl1-files-from-url"
+                            },
+                            {
+                                "name": "dev-kvm",
+                                "readOnly": true,
+                                "mountPath": "/dev/kvm"
                             },
                             {
                                 "name": "dev-fuse",

--- a/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/insecure-registries.json
+++ b/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/insecure-registries.json
@@ -47,6 +47,12 @@
                         }
                     },
                     {
+                        "name": "dev-kvm",
+                        "hostPath": {
+                            "path": "/dev/kvm"
+                        }
+                    },
+                    {
                         "name": "dev-fuse",
                         "hostPath": {
                             "path": "/dev/fuse"
@@ -118,6 +124,11 @@
                                 "readOnly": true,
                                 "mountPath": "/clabernetes/files-from-url.yaml",
                                 "subPath": "srl1-files-from-url"
+                            },
+                            {
+                                "name": "dev-kvm",
+                                "readOnly": true,
+                                "mountPath": "/dev/kvm"
                             },
                             {
                                 "name": "dev-fuse",

--- a/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/launcher-log-level.json
+++ b/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/launcher-log-level.json
@@ -47,6 +47,12 @@
                         }
                     },
                     {
+                        "name": "dev-kvm",
+                        "hostPath": {
+                            "path": "/dev/kvm"
+                        }
+                    },
+                    {
                         "name": "dev-fuse",
                         "hostPath": {
                             "path": "/dev/fuse"
@@ -114,6 +120,11 @@
                                 "readOnly": true,
                                 "mountPath": "/clabernetes/files-from-url.yaml",
                                 "subPath": "srl1-files-from-url"
+                            },
+                            {
+                                "name": "dev-kvm",
+                                "readOnly": true,
+                                "mountPath": "/dev/kvm"
                             },
                             {
                                 "name": "dev-fuse",

--- a/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/simple.json
+++ b/controllers/topology/reconciler/test-fixtures/golden/deployment/render-deployment/simple.json
@@ -47,6 +47,12 @@
                         }
                     },
                     {
+                        "name": "dev-kvm",
+                        "hostPath": {
+                            "path": "/dev/kvm"
+                        }
+                    },
+                    {
                         "name": "dev-fuse",
                         "hostPath": {
                             "path": "/dev/fuse"
@@ -114,6 +120,11 @@
                                 "readOnly": true,
                                 "mountPath": "/clabernetes/files-from-url.yaml",
                                 "subPath": "srl1-files-from-url"
+                            },
+                            {
+                                "name": "dev-kvm",
+                                "readOnly": true,
+                                "mountPath": "/dev/kvm"
                             },
                             {
                                 "name": "dev-fuse",


### PR DESCRIPTION
this should be ok (right?... RIGHT??). if the path doesn't exist on the node it gets created (at least for normal paths)... unclear what that means for character devices? I don't *think* this can hurt anything since 99/100 /dev/kvm should exist already I think?