### PR TITLE
fix: dont forget to actually export/re-import image if its present in cri

### DIFF
--- a/http/alive.go
+++ b/http/alive.go
@@ -11,6 +11,8 @@ const (
 func (m *manager) aliveHandler(w http.ResponseWriter, r *http.Request) {
 	if !m.returnedReady {
 		m.logRequest(r)
+
+		m.returnedReady = true
 	}
 
 	if m.managerReadyF() {


### PR DESCRIPTION
title. fixes issue where we just totally bailed outa the pull through process if the image is already in the cri. this obviously breaks things if the image can't be pulled publicly -- not to mention even if the image is public this makes us pull it again for no reason. 