### PR TITLE
Added file mode extraction for clabverter

### DIFF
--- a/clabverter/assets/topology.yaml.template
+++ b/clabverter/assets/topology.yaml.template
@@ -22,7 +22,7 @@ spec:
           - filePath: {{ $nodeFile.FilePath }}
             configMapName: {{ $nodeFile.ConfigMapName }}
             configMapPath: {{ $nodeFile.FileName }}
-            mode: read
+            Mode: {{ $nodeFile.FileMode }}
           {{- end }}
       {{- end }}
     {{- end }}

--- a/clabverter/assets/topology.yaml.template
+++ b/clabverter/assets/topology.yaml.template
@@ -22,7 +22,7 @@ spec:
           - filePath: {{ $nodeFile.FilePath }}
             configMapName: {{ $nodeFile.ConfigMapName }}
             configMapPath: {{ $nodeFile.FileName }}
-            Mode: {{ $nodeFile.FileMode }}
+            mode: {{ $nodeFile.FileMode }}
           {{- end }}
       {{- end }}
     {{- end }}

--- a/clabverter/types.go
+++ b/clabverter/types.go
@@ -17,6 +17,7 @@ type topologyConfigMapTemplateVars struct {
 	ConfigMapName string
 	FilePath      string
 	FileName      string
+	FileMode      string
 }
 
 type topologyFileFromURLTemplateVars struct {
@@ -42,6 +43,10 @@ type renderedContent struct {
 type sourceDestinationPathPair struct {
 	sourcePath      string
 	destinationPath string
+	// mode is either "read" (default) or "execute"
+	// and reflects the mode of the source file
+	// referenced by the sourcePath
+	mode string
 }
 
 type gitHubPathInfo struct {

--- a/constants/common.go
+++ b/constants/common.go
@@ -34,10 +34,11 @@ const (
 	// UDP is... UDP.
 	UDP = "UDP"
 
-	// Read is "read". Used for configmap mount permissions in the TopologySpec/FilesFromConfigMap.
-	Read = "read"
-
-	// Execute is "execute". Used for configmap mount permissions in the
+	// FileModeRead is "read". Used for configmap mount permissions in the
 	// TopologySpec/FilesFromConfigMap.
-	Execute = "execute"
+	FileModeRead = "read"
+
+	// FileModeExecute is "execute". Used for configmap mount permissions in the
+	// TopologySpec/FilesFromConfigMap.
+	FileModeExecute = "execute"
 )

--- a/controllers/topology/deployment.go
+++ b/controllers/topology/deployment.go
@@ -276,11 +276,11 @@ func (r *DeploymentReconciler) renderDeploymentVolumes(
 		var mode *int32
 
 		switch podVolume.Mode {
-		case clabernetesconstants.Read:
+		case clabernetesconstants.FileModeRead:
 			mode = clabernetesutil.ToPointer(
 				int32(clabernetesconstants.PermissionsEveryoneRead),
 			)
-		case clabernetesconstants.Execute:
+		case clabernetesconstants.FileModeExecute:
 			mode = clabernetesutil.ToPointer(
 				int32(clabernetesconstants.PermissionsEveryoneReadExecute),
 			)


### PR DESCRIPTION
This PR complements #99 to support exec file permissions to be set for config maps that carry contents of executable files (shell scripts, etc).

for any binds found clabverter checks if any of user/group/other has an executable permission set on the file and if yes, the `execute` mode is associated with that file.

For licenses and startup configs the mode is always read