### PR TITLE
Clabverter to output the namespace manifest

### DIFF
--- a/clabverter/assets/namespace.yaml.template
+++ b/clabverter/assets/namespace.yaml.template
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: {{ .Name }}

--- a/clabverter/test-fixtures/golden/simple-no-explicit-namespace/c9s-srl02-ns.yaml
+++ b/clabverter/test-fixtures/golden/simple-no-explicit-namespace/c9s-srl02-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: c9s-srl02

--- a/clabverter/test-fixtures/golden/simple/notclabernetes-ns.yaml
+++ b/clabverter/test-fixtures/golden/simple/notclabernetes-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: notclabernetes


### PR DESCRIPTION
To stand by the promises of Clabverter, we need to make the deployment process as smooth as possible.

This PR adds namespace manifest to the list of manifests output'ed by the Clabverter and removes yet another manual step from the installation instructions. 