### PR TITLE
Added `disableExpose` clabverter flag

### DIFF
--- a/clabverter/assets/topology.yaml.template
+++ b/clabverter/assets/topology.yaml.template
@@ -37,6 +37,10 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+  {{- if .DisableExpose }}
+  expose:
+    disableExpose: true
+  {{- end }}
   connectivity: vxlan
   definition:
     containerlab: |-

--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -29,6 +29,7 @@ func MustNewClabverter(
 	outputDirectory,
 	destinationNamespace,
 	insecureRegistries string,
+	disableExpose,
 	debug,
 	quiet,
 	stdout bool,
@@ -68,6 +69,7 @@ func MustNewClabverter(
 		githubToken:             githubToken,
 		outputDirectory:         outputDirectory,
 		stdout:                  stdout,
+		disableExpose:           disableExpose,
 		destinationNamespace:    destinationNamespace,
 		insecureRegistries:      insecureRegistriesArr,
 		startupConfigConfigMaps: make(map[string]topologyConfigMapTemplateVars),
@@ -90,6 +92,8 @@ type Clabverter struct {
 	destinationNamespace string
 
 	insecureRegistries []string
+
+	disableExpose bool
 
 	topologyPath       string
 	topologyPathParent string
@@ -428,6 +432,7 @@ func (c *Clabverter) handleManifest() error {
 			Files:              files,
 			FilesFromURL:       c.extraFilesFromURL,
 			InsecureRegistries: c.insecureRegistries,
+			DisableExpose:      c.disableExpose,
 		},
 	)
 	if err != nil {

--- a/clabverter/clabverter_test.go
+++ b/clabverter/clabverter_test.go
@@ -24,6 +24,7 @@ func TestClabvert(t *testing.T) {
 		topologyFile         string
 		destinationNamespace string
 		insecureRegistries   string
+		disableExpose        bool
 	}{
 		{
 			name:                 "simple",
@@ -35,6 +36,7 @@ func TestClabvert(t *testing.T) {
 			name:               "simple-no-explicit-namespace",
 			topologyFile:       "test-fixtures/clabversiontest/clab.yaml",
 			insecureRegistries: "1.2.3.4",
+			disableExpose:      true,
 		},
 	}
 
@@ -79,6 +81,7 @@ func TestClabvert(t *testing.T) {
 					actualDir,
 					testCase.destinationNamespace,
 					testCase.insecureRegistries,
+					testCase.disableExpose,
 					false,
 					true,
 					false,

--- a/clabverter/test-fixtures/golden/simple-no-explicit-namespace/srl02.yaml
+++ b/clabverter/test-fixtures/golden/simple-no-explicit-namespace/srl02.yaml
@@ -66,7 +66,7 @@ spec:
       tolerations: null
   expose:
     disableAutoExpose: false
-    disableExpose: false
+    disableExpose: true
     disableNodeAliasService: false
   imagePull:
     insecureRegistries:

--- a/clabverter/types.go
+++ b/clabverter/types.go
@@ -32,6 +32,7 @@ type containerlabTemplateVars struct {
 	Files              map[string][]topologyConfigMapTemplateVars
 	FilesFromURL       map[string][]topologyFileFromURLTemplateVars
 	InsecureRegistries []string
+	DisableExpose      bool
 }
 
 type renderedContent struct {

--- a/cmd/clabverter/cli/entrypoint.go
+++ b/cmd/clabverter/cli/entrypoint.go
@@ -12,6 +12,7 @@ const (
 	outputDirectory      = "outputDirectory"
 	destinationNamespace = "destinationNamespace"
 	insecureRegistries   = "insecureRegistries"
+	disableExpose        = "disableExpose"
 	debug                = "debug"
 	quiet                = "quiet"
 	stdout               = "stdout"
@@ -52,6 +53,12 @@ If not set, clabverter will look for a file named '*.clab.y*ml'`,
 				Value:    "",
 			},
 			&cli.BoolFlag{
+				Name:     disableExpose,
+				Usage:    "disable exposing nodes via Load Balancer service",
+				Required: false,
+				Value:    false,
+			},
+			&cli.BoolFlag{
 				Name:     debug,
 				Usage:    "enable debug logging",
 				Required: false,
@@ -77,6 +84,7 @@ If not set, clabverter will look for a file named '*.clab.y*ml'`,
 				c.String(outputDirectory),
 				c.String(destinationNamespace),
 				c.String(insecureRegistries),
+				c.Bool(disableExpose),
 				c.Bool(debug),
 				c.Bool(quiet),
 				c.Bool(stdout),

--- a/e2e/clabverter/clabverter_basic_test.go
+++ b/e2e/clabverter/clabverter_basic_test.go
@@ -31,6 +31,7 @@ func TestClabverterBasic(t *testing.T) {
 		false,
 		false,
 		false,
+		false,
 	)
 
 	err := c.Clabvert()


### PR DESCRIPTION
For environments where LB IPs are scarse or cost money, we need to make sure users can disable nodes exposure