### PR TITLE
Do not append parent path if the path is absolute and sanitize node names

### DIFF
--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -16,6 +16,7 @@ import (
 	clabernetesutil "github.com/srl-labs/clabernetes/util"
 	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
 	clabernetesutilkubernetes "github.com/srl-labs/clabernetes/util/kubernetes"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -443,6 +444,9 @@ func (c *Clabverter) handleManifest() error {
 		})
 	}
 
+	// marshal the clab config to yaml to be included in the manifest
+	clabConfig, _ := yaml.Marshal(c.clabConfig)
+
 	var rendered bytes.Buffer
 
 	err = t.Execute(
@@ -452,7 +456,7 @@ func (c *Clabverter) handleManifest() error {
 			Namespace: c.destinationNamespace,
 			// pad w/ a newline so the template can look prettier :)
 			ClabConfig: "\n" + clabernetesutil.Indent(
-				c.rawClabConfig,
+				string(clabConfig),
 				specDefinitionIndentSpaces,
 			),
 			Files:               files,

--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -247,7 +247,8 @@ func (c *Clabverter) resolveContentAtPath(path string) ([]byte, error) {
 	} else {
 		fullyQualifiedConfigPath := path
 
-		if !strings.HasPrefix(path, c.topologyPathParent) {
+		// set the fully qualified path if the source path is not fully qualified
+		if !strings.HasPrefix(path, "/") && !strings.HasPrefix(path, c.topologyPathParent) {
 			// we may have already set this while processing bind mounts, so don't blindly add the
 			// parent path unless we need to!
 			fullyQualifiedConfigPath = fmt.Sprintf(

--- a/clabverter/files.go
+++ b/clabverter/files.go
@@ -311,7 +311,8 @@ func (c *Clabverter) resolveExtraFilesLocal(
 	for _, extraFilePath := range extraFilePaths {
 		fullyQualifiedPath := extraFilePath.sourcePath
 
-		if !strings.HasPrefix(extraFilePath.sourcePath, c.topologyPathParent) {
+		// set the fully qualified path if the source path is not fully qualified
+		if !strings.HasPrefix(extraFilePath.sourcePath, "/") && !strings.HasPrefix(extraFilePath.sourcePath, c.topologyPathParent) {
 			// we may have already set this while processing bind mounts, so don't blindly add
 			// the parent path unless we need to!
 			fullyQualifiedPath = fmt.Sprintf(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/srl-labs/clabernetes
 
-go 1.22
+go 1.22.1
 
 require (
 	github.com/carlmontanari/difflibgo v0.0.0-20231101235608-20f26fe20f37

--- a/util/kubernetes/names.go
+++ b/util/kubernetes/names.go
@@ -18,18 +18,19 @@ const (
 	NameMaxLen = 63
 )
 
+// ref. https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 type validDNSLabelConventionPatterns struct {
-	invalidChars       *regexp.Regexp
-	startsWithNonAlpha *regexp.Regexp
-	endsWithNonAlpha   *regexp.Regexp
+	invalidChars          *regexp.Regexp
+	startsWithNonAlphaNum *regexp.Regexp
+	endsWithNonAlphaNum   *regexp.Regexp
 }
 
 func getDNSLabelConventionPatterns() *validDNSLabelConventionPatterns {
 	validNSLabelConventionPatternsObjOnce.Do(func() {
 		validDNSLabelConventionPatternsObj = &validDNSLabelConventionPatterns{
-			invalidChars:       regexp.MustCompile(`[^a-z0-9\-]`),
-			startsWithNonAlpha: regexp.MustCompile(`^[^a-z]`),
-			endsWithNonAlpha:   regexp.MustCompile(`[^a-z]$`),
+			invalidChars:          regexp.MustCompile(`[^a-z0-9\-]`),
+			startsWithNonAlphaNum: regexp.MustCompile(`^[^a-z0-9]`),
+			endsWithNonAlphaNum:   regexp.MustCompile(`[^a-z0-9]$`),
 		}
 	})
 
@@ -64,8 +65,8 @@ func EnforceDNSLabelConvention(s string) string {
 
 	s = strings.ToLower(s)
 	s = p.invalidChars.ReplaceAllString(s, "-")
-	s = p.startsWithNonAlpha.ReplaceAllString(s, "z")
-	s = p.endsWithNonAlpha.ReplaceAllString(s, "z")
+	s = p.startsWithNonAlphaNum.ReplaceAllString(s, "z")
+	s = p.endsWithNonAlphaNum.ReplaceAllString(s, "z")
 
 	return s
 }


### PR DESCRIPTION
## 1 Handle absolute paths for startup configs, license and extra files

Some file paths are given in the abs format (mostly licenses that are kept centrally like in `/opt/nokia/sros/lic.key`.
This PR prevents those paths to be FQDN'ed since they are FQDN enough already.

## Underscore in the lab and node names

(I am still thinking about it, currently thinking let the user handle it themselves :D)

This is somewhat a bigger (?) problem. If an original lab definition contains underscores either in a node name or a lab name the lab will burst in flames. This is due to the same DNS label rules.

At the same time it is not uncommon to see underscores in the clab files. So I was thinking where this can be fixed. And I see the following options:

1. leave it as it is, maybe add an error if underscores are detected. Least preferred, as this becomes a user's problem which they might not want to solve.
2. use clabverter and substitute all underscored strings with dashes. A sane alternative, should only affect the initial raw config string, but seems very hard to implement, because underscores can be seen in the file names, kinds...
3. implement a custom unmarshaller (done in this pr) that would apply the enforceDNSLabel processing on all node names and lab name. This works, but introduces another problem where the raw config doesn't match the processed one. I think I will have to try (2) variant instead.



## 3 VS Code and go directive in 
vscode went batshit crazy with go version being 1.22, until I set it to 1.22.1

It couldn't find the toolchain, which is a new thing since 1.21, but I am not sure why it can't live with 1.22 go directive.

Since this was also noticed by other users I think it is not too bad to set it to the full min version value (1.22.1)