### PR TITLE
Clabverter : ensure deletion of the old clabverter logging instance before creating a new one

### DIFF
--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -54,6 +54,10 @@ func MustNewClabverter(
 
 	logManager := claberneteslogging.GetManager()
 
+	if oldClabverterLogger, _ := logManager.GetLogger(clabernetesconstants.Clabverter); oldClabverterLogger != nil {
+		logManager.DeleteLogger(clabernetesconstants.Clabverter)
+	}
+
 	clabverterLogger := logManager.MustRegisterAndGetLogger(
 		clabernetesconstants.Clabverter,
 		logLevel,

--- a/clabverter/clabverter.go
+++ b/clabverter/clabverter.go
@@ -54,7 +54,8 @@ func MustNewClabverter(
 
 	logManager := claberneteslogging.GetManager()
 
-	if oldClabverterLogger, _ := logManager.GetLogger(clabernetesconstants.Clabverter); oldClabverterLogger != nil {
+	oldClabverterLogger, _ := logManager.GetLogger(clabernetesconstants.Clabverter)
+	if oldClabverterLogger != nil {
 		logManager.DeleteLogger(clabernetesconstants.Clabverter)
 	}
 


### PR DESCRIPTION
Hi, 

When using Clabverter as a Golang module, we need to use the ``MustNewClabverter()`` function to create a new clabverter instance. 
The functions calls ``MustRegisterAndGetLogger()`` that panics if a logging instance of clabverter already exists. 

This PR patches the ``MustNewClabverter`` by checking if the logging instance already exists. If so, it get destroyed and recreated. 