### PR TITLE
fix: dont let deepequal freak out on empty vs nil slice when disableExpose is true

### DIFF
--- a/controllers/topology/definitioncontainerlab.go
+++ b/controllers/topology/definitioncontainerlab.go
@@ -361,6 +361,10 @@ func (p *containerlabDefinitionProcessor) processConfigForNode(
 
 		deepCopiedDefaults.Ports = defaultPorts
 		nodeDefinition.Ports = nodePorts
+	} else {
+		// zero value of slice is nil, that breaks deep equal checks later, so ensure we set to
+		// a non-zero (but empty) slice
+		nodeDefinition.Ports = []string{}
 	}
 
 	p.reconcileData.ResolvedConfigs[nodeName] = &clabernetesutilcontainerlab.Config{


### PR DESCRIPTION
resolves #164 (hopefully :P -- but I tested it and could repro and this fixes it!)