### PR TITLE
feat: support containerlab host links definitions

### DIFF
--- a/constants/common.go
+++ b/constants/common.go
@@ -42,6 +42,6 @@ const (
 	// TopologySpec/FilesFromConfigMap.
 	FileModeExecute = "execute"
 
-	// Keyword to define host links endpoints.
+	// HostKeyword is the containerlab reserved keyword to define host links endpoints.
 	HostKeyword = "host"
 )

--- a/constants/common.go
+++ b/constants/common.go
@@ -42,6 +42,6 @@ const (
 	// TopologySpec/FilesFromConfigMap.
 	FileModeExecute = "execute"
 
-	// Keyword to define host links endpoints
+	// Keyword to define host links endpoints.
 	HostKeyword = "host"
 )

--- a/constants/common.go
+++ b/constants/common.go
@@ -41,4 +41,7 @@ const (
 	// FileModeExecute is "execute". Used for configmap mount permissions in the
 	// TopologySpec/FilesFromConfigMap.
 	FileModeExecute = "execute"
+
+	// Keyword to define host links endpoints
+	HostKeyword = "host"
 )

--- a/controllers/topology/definition_test.go
+++ b/controllers/topology/definition_test.go
@@ -25,6 +25,78 @@ func TestDefinitionProcess(t *testing.T) {
 		removeTopologyPrefix bool
 	}{
 		{
+			name: "containerlab-host-and-links",
+			inTopology: &clabernetesapisv1alpha1.Topology{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "process-containerlab-definition-host-and-links-test",
+					Namespace: "clabernetes",
+				},
+				Spec: clabernetesapisv1alpha1.TopologySpec{
+					Definition: clabernetesapisv1alpha1.Definition{
+						Containerlab: `---
+    name: test
+    topology:
+      nodes:
+        srl1:
+          kind: srl
+          image: ghcr.io/nokia/srlinux
+        srl2:
+          kind: srl
+          image: ghcr.io/nokia/srlinux
+      links:
+        - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+        - endpoints: ["srl1:e3-3", "host:eth3-3"]
+`,
+					},
+				},
+			},
+			reconcileData: &clabernetescontrollerstopology.ReconcileData{
+				Kind:           "containerlab",
+				ResolvedHashes: clabernetesapisv1alpha1.ReconcileHashes{},
+				ResolvedConfigs: map[string]*clabernetesutilcontainerlab.Config{
+					"srl1": {},
+					"srl2": {},
+				},
+				ResolvedTunnels: map[string][]*clabernetesapisv1alpha1.PointToPointTunnel{
+					"srl1": {},
+					"srl2": {},
+				},
+			},
+			removeTopologyPrefix: false,
+		},
+		{
+			name: "containerlab-host-link",
+			inTopology: &clabernetesapisv1alpha1.Topology{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "process-containerlab-definition-host-link-test",
+					Namespace: "clabernetes",
+				},
+				Spec: clabernetesapisv1alpha1.TopologySpec{
+					Definition: clabernetesapisv1alpha1.Definition{
+						Containerlab: `---
+    name: test
+    topology:
+      nodes:
+        srl1:
+          kind: srl
+          image: ghcr.io/nokia/srlinux
+      links:
+        - endpoints: ["srl1:e1-1", "host:srl1-e1-1"]
+`,
+					},
+				},
+			},
+			reconcileData: &clabernetescontrollerstopology.ReconcileData{
+				Kind:           "containerlab",
+				ResolvedHashes: clabernetesapisv1alpha1.ReconcileHashes{},
+				ResolvedConfigs: map[string]*clabernetesutilcontainerlab.Config{
+					"srl1": {},
+				},
+				ResolvedTunnels: map[string][]*clabernetesapisv1alpha1.PointToPointTunnel{},
+			},
+			removeTopologyPrefix: false,
+		},
+		{
 			name: "containerlab-simple",
 			inTopology: &clabernetesapisv1alpha1.Topology{
 				ObjectMeta: metav1.ObjectMeta{

--- a/controllers/topology/definitioncontainerlab.go
+++ b/controllers/topology/definitioncontainerlab.go
@@ -446,6 +446,23 @@ func (p *containerlabDefinitionProcessor) processConfigForNode(
 			uninterestingEndpoint = endpointA
 		}
 
+		var hostEntryDestiny string
+		if endpointB.NodeName == clabernetesconstants.HostKeyword {
+			// It is a containerlab host entry, so the original provided interface is preserved
+			hostEntryDestiny = fmt.Sprintf(
+				"%s:%s",
+				clabernetesconstants.HostKeyword,
+				uninterestingEndpoint.InterfaceName,
+			)
+		} else {
+			hostEntryDestiny = fmt.Sprintf(
+				"%s:%s-%s",
+				clabernetesconstants.HostKeyword,
+				interestingEndpoint.NodeName,
+				interestingEndpoint.InterfaceName,
+			)
+		}
+
 		p.reconcileData.ResolvedConfigs[nodeName].Topology.Links = append(
 			p.reconcileData.ResolvedConfigs[nodeName].Topology.Links,
 			&clabernetesutilcontainerlab.LinkDefinition{
@@ -456,15 +473,16 @@ func (p *containerlabDefinitionProcessor) processConfigForNode(
 							interestingEndpoint.NodeName,
 							interestingEndpoint.InterfaceName,
 						),
-						fmt.Sprintf(
-							"host:%s-%s",
-							interestingEndpoint.NodeName,
-							interestingEndpoint.InterfaceName,
-						),
+						hostEntryDestiny,
 					},
 				},
 			},
 		)
+
+		if endpointB.NodeName == clabernetesconstants.HostKeyword {
+			// This is containerlab host entry, so no VxLAN is required
+			continue
+		}
 
 		p.reconcileData.ResolvedTunnels[nodeName] = append(
 			p.reconcileData.ResolvedTunnels[nodeName],

--- a/controllers/topology/definitioncontainerlab.go
+++ b/controllers/topology/definitioncontainerlab.go
@@ -467,21 +467,17 @@ func (p *containerlabDefinitionProcessor) processConfigForNode(
 			uninterestingEndpoint = endpointA
 		}
 
-		hostEntryDestiny := getDestinyLinkEndpoint(
-			endpointB.NodeName,
-			interestingEndpoint,
+		hostEntryDestiny := getDestinyLinkEndpoint(endpointB.NodeName, interestingEndpoint,
 			uninterestingEndpoint)
 		p.reconcileData.ResolvedConfigs[nodeName].Topology.Links = append(
 			p.reconcileData.ResolvedConfigs[nodeName].Topology.Links,
 			&clabernetesutilcontainerlab.LinkDefinition{
 				LinkConfig: clabernetesutilcontainerlab.LinkConfig{
 					Endpoints: []string{
-						fmt.Sprintf(
-							"%s:%s",
+						fmt.Sprintf("%s:%s",
 							interestingEndpoint.NodeName,
 							interestingEndpoint.InterfaceName,
-						),
-						hostEntryDestiny,
+						), hostEntryDestiny,
 					},
 				},
 			},

--- a/controllers/topology/definitioncontainerlab.go
+++ b/controllers/topology/definitioncontainerlab.go
@@ -335,7 +335,8 @@ func getKindsForNode(
 	return nil
 }
 
-func getDestinyLinkEndpoint(targetNode string,
+func getDestinationLinkEndpoint(
+	targetNode string,
 	interestingEndpoint clabernetesapisv1alpha1.LinkEndpoint,
 	uninterestingEndpoint clabernetesapisv1alpha1.LinkEndpoint,
 ) string {
@@ -467,8 +468,6 @@ func (p *containerlabDefinitionProcessor) processConfigForNode(
 			uninterestingEndpoint = endpointA
 		}
 
-		hostEntryDestiny := getDestinyLinkEndpoint(endpointB.NodeName, interestingEndpoint,
-			uninterestingEndpoint)
 		p.reconcileData.ResolvedConfigs[nodeName].Topology.Links = append(
 			p.reconcileData.ResolvedConfigs[nodeName].Topology.Links,
 			&clabernetesutilcontainerlab.LinkDefinition{
@@ -477,7 +476,12 @@ func (p *containerlabDefinitionProcessor) processConfigForNode(
 						fmt.Sprintf("%s:%s",
 							interestingEndpoint.NodeName,
 							interestingEndpoint.InterfaceName,
-						), hostEntryDestiny,
+						),
+						getDestinationLinkEndpoint(
+							endpointB.NodeName,
+							interestingEndpoint,
+							uninterestingEndpoint,
+						),
 					},
 				},
 			},

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
@@ -1,0 +1,289 @@
+{
+    "Kind": "containerlab",
+    "PreviousHashes": {
+        "config": "",
+        "exposedPorts": "",
+        "filesFromURL": null,
+        "imagePullSecrets": ""
+    },
+    "ResolvedHashes": {
+        "config": "",
+        "exposedPorts": "",
+        "filesFromURL": null,
+        "imagePullSecrets": ""
+    },
+    "PreviousConfigs": null,
+    "ResolvedConfigs": {
+        "srl1": {
+            "Name": "clabernetes-srl1",
+            "Prefix": "",
+            "Mgmt": null,
+            "Topology": {
+                "Defaults": {
+                    "Kind": "",
+                    "Group": "",
+                    "Type": "",
+                    "StartupConfig": "",
+                    "StartupDelay": 0,
+                    "EnforceStartupConfig": false,
+                    "AutoRemove": null,
+                    "Config": null,
+                    "Image": "",
+                    "ImagePullPolicy": "",
+                    "License": "",
+                    "Position": "",
+                    "Entrypoint": "",
+                    "Cmd": "",
+                    "SANs": null,
+                    "Exec": null,
+                    "Binds": null,
+                    "Ports": [
+                        "60000:21/tcp",
+                        "60001:22/tcp",
+                        "60002:23/tcp",
+                        "60003:80/tcp",
+                        "60000:161/udp",
+                        "60004:443/tcp",
+                        "60005:830/tcp",
+                        "60006:5000/tcp",
+                        "60007:5900/tcp",
+                        "60008:6030/tcp",
+                        "60009:9339/tcp",
+                        "60010:9340/tcp",
+                        "60011:9559/tcp",
+                        "60012:57400/tcp"
+                    ],
+                    "MgmtIPv4": "",
+                    "MgmtIPv6": "",
+                    "Publish": null,
+                    "Env": null,
+                    "EnvFiles": null,
+                    "User": "",
+                    "Labels": null,
+                    "NetworkMode": "",
+                    "Sandbox": "",
+                    "Kernel": "",
+                    "Runtime": "",
+                    "CPU": 0,
+                    "CPUSet": "",
+                    "Memory": "",
+                    "Sysctls": null,
+                    "Extras": null,
+                    "WaitFor": null,
+                    "DNS": null,
+                    "Certificate": null
+                },
+                "Kinds": null,
+                "Nodes": {
+                    "srl1": {
+                        "Kind": "srl",
+                        "Group": "",
+                        "Type": "",
+                        "StartupConfig": "",
+                        "StartupDelay": 0,
+                        "EnforceStartupConfig": false,
+                        "AutoRemove": null,
+                        "Config": null,
+                        "Image": "ghcr.io/nokia/srlinux",
+                        "ImagePullPolicy": "",
+                        "License": "",
+                        "Position": "",
+                        "Entrypoint": "",
+                        "Cmd": "",
+                        "SANs": null,
+                        "Exec": null,
+                        "Binds": null,
+                        "Ports": [],
+                        "MgmtIPv4": "",
+                        "MgmtIPv6": "",
+                        "Publish": null,
+                        "Env": null,
+                        "EnvFiles": null,
+                        "User": "",
+                        "Labels": null,
+                        "NetworkMode": "",
+                        "Sandbox": "",
+                        "Kernel": "",
+                        "Runtime": "",
+                        "CPU": 0,
+                        "CPUSet": "",
+                        "Memory": "",
+                        "Sysctls": null,
+                        "Extras": null,
+                        "WaitFor": null,
+                        "DNS": null,
+                        "Certificate": null
+                    }
+                },
+                "Links": [
+                    {
+                        "Type": "",
+                        "Endpoints": [
+                            "srl1:e1-1",
+                            "host:srl1-e1-1"
+                        ],
+                        "Labels": null,
+                        "Vars": null,
+                        "MTU": 0
+                    },
+                    {
+                        "Type": "",
+                        "Endpoints": [
+                            "srl1:e3-3",
+                            "host:eth3-3"
+                        ],
+                        "Labels": null,
+                        "Vars": null,
+                        "MTU": 0
+                    }                    
+                ]
+            },
+            "Debug": false
+        },
+        "srl2": {
+            "Name": "clabernetes-srl2",
+            "Prefix": "",
+            "Mgmt": null,
+            "Topology": {
+                "Defaults": {
+                    "Kind": "",
+                    "Group": "",
+                    "Type": "",
+                    "StartupConfig": "",
+                    "StartupDelay": 0,
+                    "EnforceStartupConfig": false,
+                    "AutoRemove": null,
+                    "Config": null,
+                    "Image": "",
+                    "ImagePullPolicy": "",
+                    "License": "",
+                    "Position": "",
+                    "Entrypoint": "",
+                    "Cmd": "",
+                    "SANs": null,
+                    "Exec": null,
+                    "Binds": null,
+                    "Ports": [
+                        "60000:21/tcp",
+                        "60001:22/tcp",
+                        "60002:23/tcp",
+                        "60003:80/tcp",
+                        "60000:161/udp",
+                        "60004:443/tcp",
+                        "60005:830/tcp",
+                        "60006:5000/tcp",
+                        "60007:5900/tcp",
+                        "60008:6030/tcp",
+                        "60009:9339/tcp",
+                        "60010:9340/tcp",
+                        "60011:9559/tcp",
+                        "60012:57400/tcp"
+                    ],
+                    "MgmtIPv4": "",
+                    "MgmtIPv6": "",
+                    "Publish": null,
+                    "Env": null,
+                    "EnvFiles": null,
+                    "User": "",
+                    "Labels": null,
+                    "NetworkMode": "",
+                    "Sandbox": "",
+                    "Kernel": "",
+                    "Runtime": "",
+                    "CPU": 0,
+                    "CPUSet": "",
+                    "Memory": "",
+                    "Sysctls": null,
+                    "Extras": null,
+                    "WaitFor": null,
+                    "DNS": null,
+                    "Certificate": null
+                },
+                "Kinds": null,
+                "Nodes": {
+                    "srl2": {
+                        "Kind": "srl",
+                        "Group": "",
+                        "Type": "",
+                        "StartupConfig": "",
+                        "StartupDelay": 0,
+                        "EnforceStartupConfig": false,
+                        "AutoRemove": null,
+                        "Config": null,
+                        "Image": "ghcr.io/nokia/srlinux",
+                        "ImagePullPolicy": "",
+                        "License": "",
+                        "Position": "",
+                        "Entrypoint": "",
+                        "Cmd": "",
+                        "SANs": null,
+                        "Exec": null,
+                        "Binds": null,
+                        "Ports": [],
+                        "MgmtIPv4": "",
+                        "MgmtIPv6": "",
+                        "Publish": null,
+                        "Env": null,
+                        "EnvFiles": null,
+                        "User": "",
+                        "Labels": null,
+                        "NetworkMode": "",
+                        "Sandbox": "",
+                        "Kernel": "",
+                        "Runtime": "",
+                        "CPU": 0,
+                        "CPUSet": "",
+                        "Memory": "",
+                        "Sysctls": null,
+                        "Extras": null,
+                        "WaitFor": null,
+                        "DNS": null,
+                        "Certificate": null
+                    }
+                },
+                "Links": [
+                    {
+                        "Type": "",
+                        "Endpoints": [
+                            "srl2:e1-1",
+                            "host:srl2-e1-1"
+                        ],
+                        "Labels": null,
+                        "Vars": null,
+                        "MTU": 0
+                    }
+                ]
+            },
+            "Debug": false
+        }
+    },
+    "ResolvedConfigsBytes": null,
+    "ResolvedTunnels": {
+        "srl1": [
+            {
+                "tunnelID": 0,
+                "destination": "process-containerlab-definition-host-and-links-test-srl2-vx.clabernetes.svc.cluster.local",
+                "localNode": "srl1",
+                "localInterface": "e1-1",
+                "remoteNode": "srl2",
+                "remoteInterface": "e1-1"
+            }
+        ],
+        "srl2": [
+            {
+                "tunnelID": 0,
+                "destination": "process-containerlab-definition-host-and-links-test-srl1-vx.clabernetes.svc.cluster.local",
+                "localNode": "srl2",
+                "localInterface": "e1-1",
+                "remoteNode": "srl1",
+                "remoteInterface": "e1-1"
+            }
+        ]
+    },
+    "ResolvedExposedPorts": null,
+    "PreviousNodeStatuses": null,
+    "NodeStatuses": null,
+    "TopologyReady": false,
+    "NodesNeedingReboot": null,
+    "ShouldUpdateResource": false
+}

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-host-link.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-host-link.json
@@ -1,0 +1,142 @@
+{
+    "Kind": "containerlab",
+    "PreviousHashes": {
+        "config": "",
+        "exposedPorts": "",
+        "filesFromURL": null,
+        "imagePullSecrets": ""
+    },
+    "ResolvedHashes": {
+        "config": "",
+        "exposedPorts": "",
+        "filesFromURL": null,
+        "imagePullSecrets": ""
+    },
+    "PreviousConfigs": null,
+    "ResolvedConfigs": {
+        "srl1": {
+            "Name": "clabernetes-srl1",
+            "Prefix": "",
+            "Mgmt": null,
+            "Topology": {
+                "Defaults": {
+                    "Kind": "",
+                    "Group": "",
+                    "Type": "",
+                    "StartupConfig": "",
+                    "StartupDelay": 0,
+                    "EnforceStartupConfig": false,
+                    "AutoRemove": null,
+                    "Config": null,
+                    "Image": "",
+                    "ImagePullPolicy": "",
+                    "License": "",
+                    "Position": "",
+                    "Entrypoint": "",
+                    "Cmd": "",
+                    "SANs": null,
+                    "Exec": null,
+                    "Binds": null,
+                    "Ports": [
+                        "60000:21/tcp",
+                        "60001:22/tcp",
+                        "60002:23/tcp",
+                        "60003:80/tcp",
+                        "60000:161/udp",
+                        "60004:443/tcp",
+                        "60005:830/tcp",
+                        "60006:5000/tcp",
+                        "60007:5900/tcp",
+                        "60008:6030/tcp",
+                        "60009:9339/tcp",
+                        "60010:9340/tcp",
+                        "60011:9559/tcp",
+                        "60012:57400/tcp"
+                    ],
+                    "MgmtIPv4": "",
+                    "MgmtIPv6": "",
+                    "Publish": null,
+                    "Env": null,
+                    "EnvFiles": null,
+                    "User": "",
+                    "Labels": null,
+                    "NetworkMode": "",
+                    "Sandbox": "",
+                    "Kernel": "",
+                    "Runtime": "",
+                    "CPU": 0,
+                    "CPUSet": "",
+                    "Memory": "",
+                    "Sysctls": null,
+                    "Extras": null,
+                    "WaitFor": null,
+                    "DNS": null,
+                    "Certificate": null
+                },
+                "Kinds": null,
+                "Nodes": {
+                    "srl1": {
+                        "Kind": "srl",
+                        "Group": "",
+                        "Type": "",
+                        "StartupConfig": "",
+                        "StartupDelay": 0,
+                        "EnforceStartupConfig": false,
+                        "AutoRemove": null,
+                        "Config": null,
+                        "Image": "ghcr.io/nokia/srlinux",
+                        "ImagePullPolicy": "",
+                        "License": "",
+                        "Position": "",
+                        "Entrypoint": "",
+                        "Cmd": "",
+                        "SANs": null,
+                        "Exec": null,
+                        "Binds": null,
+                        "Ports": [],
+                        "MgmtIPv4": "",
+                        "MgmtIPv6": "",
+                        "Publish": null,
+                        "Env": null,
+                        "EnvFiles": null,
+                        "User": "",
+                        "Labels": null,
+                        "NetworkMode": "",
+                        "Sandbox": "",
+                        "Kernel": "",
+                        "Runtime": "",
+                        "CPU": 0,
+                        "CPUSet": "",
+                        "Memory": "",
+                        "Sysctls": null,
+                        "Extras": null,
+                        "WaitFor": null,
+                        "DNS": null,
+                        "Certificate": null
+                    }
+                },
+                "Links": [
+                    {
+                        "Type": "",
+                        "Endpoints": [
+                            "srl1:e1-1",
+                            "host:srl1-e1-1"
+                        ],
+                        "Labels": null,
+                        "Vars": null,
+                        "MTU": 0
+                    }
+                ]
+            },
+            "Debug": false
+        }
+    },
+    "ResolvedConfigsBytes": null,
+    "ResolvedTunnels": {},
+    "ResolvedExposedPorts": null,
+    "PreviousNodeStatuses": null,
+    "NodeStatuses": null,
+    "TopologyReady": false,
+    "NodesNeedingReboot": null,
+    "ShouldUpdateResource": false
+}

--- a/e2e/clabverter/test-fixtures/basic_clab.yaml
+++ b/e2e/clabverter/test-fixtures/basic_clab.yaml
@@ -12,3 +12,4 @@ topology:
 
   links:
     - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+    - endpoints: ["srl1:e1-3", "host:eth13"]

--- a/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
+++ b/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
@@ -22,7 +22,7 @@ spec:
 
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]
-          - endpoints: ["srl1:e3-3", "host:eth13"]
+          - endpoints: ["srl1:e1-3", "host:eth13"]
   deployment:
     containerlabTimeout: ""
     persistence:

--- a/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
+++ b/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
@@ -71,7 +71,7 @@ status:
                   - host:srl1-e1-1
               - endpoints:
                   - srl1:e1-3
-                  - host:eth13
+                  - host:srl1-e1-3
       debug: false
     srl2: |
       name: clabernetes-srl2
@@ -140,7 +140,7 @@ status:
         - 161
   kind: containerlab
   reconcileHashes:
-    config: 25ea403243c3741d3013049756aa02db0ad8dc3d0d9bf803dc1576f9dda33649
+    config: a353337600caab93cbf5ed5ea4f3d3c92cda098968332a90ec7773041b692214
     filesFromURL: {}
     imagePullSecrets: 37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570
   removeTopologyPrefix: false

--- a/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
+++ b/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
@@ -22,6 +22,7 @@ spec:
 
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+          - endpoints: ["srl1:e3-3", "host:eth13"]
   deployment:
     containerlabTimeout: ""
     persistence:
@@ -68,6 +69,9 @@ status:
               - endpoints:
                   - srl1:e1-1
                   - host:srl1-e1-1
+              - endpoints:
+                  - srl1:e1-3
+                  - host:eth13
       debug: false
     srl2: |
       name: clabernetes-srl2

--- a/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
+++ b/e2e/clabverter/test-fixtures/golden/10-topology.clabverter-basic.yaml
@@ -71,7 +71,7 @@ status:
                   - host:srl1-e1-1
               - endpoints:
                   - srl1:e1-3
-                  - host:srl1-e1-3
+                  - host:eth13
       debug: false
     srl2: |
       name: clabernetes-srl2
@@ -140,7 +140,7 @@ status:
         - 161
   kind: containerlab
   reconcileHashes:
-    config: a353337600caab93cbf5ed5ea4f3d3c92cda098968332a90ec7773041b692214
+    config: 281b4c792b37781a3546af8c79ca929098fbf7d197b0067195646bc615e0fc21
     filesFromURL: {}
     imagePullSecrets: 37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570
   removeTopologyPrefix: false

--- a/e2e/topology/basic/test-fixtures/20-apply.yaml
+++ b/e2e/topology/basic/test-fixtures/20-apply.yaml
@@ -18,3 +18,4 @@ spec:
             image: ghcr.io/nokia/srlinux
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+          - endpoints: ["srl1:e1-3", "host:eth13"]

--- a/e2e/topology/basic/test-fixtures/golden/20-connectivity.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-connectivity.topology-basic.yaml
@@ -17,12 +17,6 @@ spec:
         remoteInterface: e1-1
         remoteNode: srl2
         tunnelID: 1
-      - destination: topology-basic-host-vx.NAMESPACE.svc.cluster.local
-        localInterface: e1-3
-        localNode: srl1
-        remoteInterface: eth13
-        remoteNode: host
-        tunnelID: 2
     srl2:
       - destination: topology-basic-srl1-vx.NAMESPACE.svc.cluster.local
         localInterface: e1-1

--- a/e2e/topology/basic/test-fixtures/golden/20-connectivity.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-connectivity.topology-basic.yaml
@@ -17,6 +17,12 @@ spec:
         remoteInterface: e1-1
         remoteNode: srl2
         tunnelID: 1
+      - destination: topology-basic-host-vx.NAMESPACE.svc.cluster.local
+        localInterface: e1-3
+        localNode: srl1
+        remoteInterface: eth13
+        remoteNode: host
+        tunnelID: 2
     srl2:
       - destination: topology-basic-srl1-vx.NAMESPACE.svc.cluster.local
         localInterface: e1-1

--- a/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
@@ -20,6 +20,7 @@ spec:
             image: ghcr.io/nokia/srlinux
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+          - endpoints: ["srl1:e1-3", "host:eth13"]
   deployment:
     containerlabTimeout: ""
     persistence:
@@ -66,6 +67,9 @@ status:
               - endpoints:
                   - srl1:e1-1
                   - host:srl1-e1-1
+              - endpoints:
+                  - srl1:e1-3
+                  - host:eth13
       debug: false
     srl2: |
       name: clabernetes-srl2

--- a/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
@@ -138,7 +138,7 @@ status:
         - 161
   kind: containerlab
   reconcileHashes:
-    config: 281b4c792b37781a3546af8c79ca929098fbf7d197b0067195646bc615e0fc21
+    config: 25ea403243c3741d3013049756aa02db0ad8dc3d0d9bf803dc1576f9dda33649
     filesFromURL: {}
     imagePullSecrets: 37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570
   removeTopologyPrefix: false

--- a/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
@@ -69,7 +69,7 @@ status:
                   - host:srl1-e1-1
               - endpoints:
                   - srl1:e1-3
-                  - host:srl1-e1-3
+                  - host:eth13
       debug: false
     srl2: |
       name: clabernetes-srl2
@@ -138,7 +138,7 @@ status:
         - 161
   kind: containerlab
   reconcileHashes:
-    config: a353337600caab93cbf5ed5ea4f3d3c92cda098968332a90ec7773041b692214
+    config: 281b4c792b37781a3546af8c79ca929098fbf7d197b0067195646bc615e0fc21
     filesFromURL: {}
     imagePullSecrets: 37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570
   removeTopologyPrefix: false

--- a/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
@@ -138,7 +138,7 @@ status:
         - 161
   kind: containerlab
   reconcileHashes:
-    config: 25ea403243c3741d3013049756aa02db0ad8dc3d0d9bf803dc1576f9dda33649
+    config: 281b4c792b37781a3546af8c79ca929098fbf7d197b0067195646bc615e0fc21
     filesFromURL: {}
     imagePullSecrets: 37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570
   removeTopologyPrefix: false

--- a/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-topology.topology-basic.yaml
@@ -69,7 +69,7 @@ status:
                   - host:srl1-e1-1
               - endpoints:
                   - srl1:e1-3
-                  - host:eth13
+                  - host:srl1-e1-3
       debug: false
     srl2: |
       name: clabernetes-srl2
@@ -138,7 +138,7 @@ status:
         - 161
   kind: containerlab
   reconcileHashes:
-    config: 25ea403243c3741d3013049756aa02db0ad8dc3d0d9bf803dc1576f9dda33649
+    config: a353337600caab93cbf5ed5ea4f3d3c92cda098968332a90ec7773041b692214
     filesFromURL: {}
     imagePullSecrets: 37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570
   removeTopologyPrefix: false


### PR DESCRIPTION
Containerlab supports natively the [host-link](https://containerlab.dev/manual/network/#host-links) feature, and that functionality is already used by clabernetes to create network interfaces on Pods, so then VxLAN connections are configured using them.

This pull request is to support containerlab host links e.g `endpoints: ["srl1:e3-3", "host:eth3-3"]` on clabernetes.

The idea is to filter out links whose destiny is "host", so those are not considered on VxLAN creation but the expected interfaces are created on the Pod.