### PR TITLE
feat: exposing tolerations for all deployments

### DIFF
--- a/charts/clabernetes/templates/deployment.yaml
+++ b/charts/clabernetes/templates/deployment.yaml
@@ -139,6 +139,12 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+      {{- $tolerations := merge $.Values.globalTolerations $.Values.manager.deploymentTolerations }}
+      {{- if $tolerations }}
+      tolerations:
+{{ toYaml $tolerations | indent 4 }}
+      {{- end }}
+
 
 {{- if $.Values.ui.enabled }}
 ---
@@ -261,4 +267,9 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+      {{- $tolerations := merge $.Values.globalTolerations $.Values.ui.deploymentTolerations }}
+      {{- if $tolerations }}
+      tolerations:
+{{ toYaml $tolerations | indent 4 }}
+      {{- end }}
 {{- end }}

--- a/charts/clabernetes/templates/deployment.yaml
+++ b/charts/clabernetes/templates/deployment.yaml
@@ -139,10 +139,10 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
-      {{- $tolerations := merge $.Values.globalTolerations $.Values.manager.deploymentTolerations }}
+      {{- $tolerations := concat $.Values.globalTolerations $.Values.manager.deploymentTolerations }}
       {{- if $tolerations }}
       tolerations:
-{{ toYaml $tolerations | indent 4 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
 
 
@@ -267,9 +267,9 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
-      {{- $tolerations := merge $.Values.globalTolerations $.Values.ui.deploymentTolerations }}
+      {{- $tolerations := concat $.Values.globalTolerations $.Values.ui.deploymentTolerations }}
       {{- if $tolerations }}
       tolerations:
-{{ toYaml $tolerations | indent 4 }}
+{{ toYaml $tolerations | indent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/clabernetes/tests/customized_values/test-fixtures/customized_values-values.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/customized_values-values.yaml
@@ -1,5 +1,16 @@
 ---
+appName: &_appName clabernetes
+globalTolerations: &globalTolerations
+  - key: test_toleration
+    operator: Equal
+    value: "true"
+    effect: PreferNoSchedule
 manager:
+  deploymentTolerations:
+    - key: test_toleration_manager_only
+      operator: Equal
+      value: "true"
+      effect: PreferNoSchedule
   resources:
     limits:
       memory: 256Mi

--- a/charts/clabernetes/tests/customized_values/test-fixtures/golden/deployment.yaml
+++ b/charts/clabernetes/tests/customized_values/test-fixtures/golden/deployment.yaml
@@ -133,6 +133,15 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+      tolerations:
+        - effect: PreferNoSchedule
+          key: test_toleration
+          operator: Equal
+          value: "true"
+        - effect: PreferNoSchedule
+          key: test_toleration_manager_only
+          operator: Equal
+          value: "true"
 ---
 # Source: clabernetes/templates/deployment.yaml
 apiVersion: apps/v1
@@ -217,3 +226,8 @@ spec:
             failureThreshold: 2
             periodSeconds: 30
             timeoutSeconds: 5
+      tolerations:
+        - effect: PreferNoSchedule
+          key: test_toleration
+          operator: Equal
+          value: "true"

--- a/charts/clabernetes/values.yaml
+++ b/charts/clabernetes/values.yaml
@@ -13,7 +13,8 @@ appName: &_appName clabernetes
 # extra labels/annotations that are added to all objects
 globalAnnotations: &_globalAnnotations {}
 globalLabels: &_globalLabels {}
-globalTolerations: &_globalTolerations {}
+globalTolerations: &globalTolerations []
+
 
 #
 # manager options
@@ -23,7 +24,7 @@ globalTolerations: &_globalTolerations {}
 manager:
   deploymentAnnotations: {}
   deploymentLabels: {}
-  deploymentTolerations: {}
+  deploymentTolerations: []
   podAnnotations: {}
   podLabels: {}
 
@@ -158,7 +159,7 @@ ui:
 
   deploymentAnnotations: { }
   deploymentLabels: { }
-  deploymentTolerations: { }
+  deploymentTolerations: []
   podAnnotations: { }
   podLabels: { }
 

--- a/charts/clabernetes/values.yaml
+++ b/charts/clabernetes/values.yaml
@@ -13,6 +13,7 @@ appName: &_appName clabernetes
 # extra labels/annotations that are added to all objects
 globalAnnotations: &_globalAnnotations {}
 globalLabels: &_globalLabels {}
+globalTolerations: &_globalTolerations {}
 
 #
 # manager options
@@ -22,6 +23,7 @@ globalLabels: &_globalLabels {}
 manager:
   deploymentAnnotations: {}
   deploymentLabels: {}
+  deploymentTolerations: {}
   podAnnotations: {}
   podLabels: {}
 
@@ -156,6 +158,7 @@ ui:
 
   deploymentAnnotations: { }
   deploymentLabels: { }
+  deploymentTolerations: { }
   podAnnotations: { }
   podLabels: { }
 


### PR DESCRIPTION
Exposing the 'tolerations' field in values.yaml for all deployment templates. Merges global + local values allowing for global and/or per component tainting. Use-case is segregating clabernetes controllers to stable NodePools when using Karpenter to avoid disruptions.