### PR TITLE
feat: propagate containerlab healthcheck

### DIFF
--- a/clabverter/test-fixtures/clabversiontest/clab.yaml
+++ b/clabverter/test-fixtures/clabversiontest/clab.yaml
@@ -25,6 +25,12 @@ topology:
     sros2:
       kind: nokia_sros
       image: nokia_sros:latest
+      healthcheck:
+        start-period: 5
+        interval: 1
+        test:
+          - CMD-SHELL
+          - cat /etc/os-release
 
   links:
     - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/clabverter/test-fixtures/golden/simple-no-explicit-namespace/topo01.yaml
+++ b/clabverter/test-fixtures/golden/simple-no-explicit-namespace/topo01.yaml
@@ -35,6 +35,12 @@ spec:
           sros2:
             kind: nokia_sros
             image: nokia_sros:latest
+            healthcheck:
+              start-period: 5
+              interval: 1
+              test:
+                - CMD-SHELL
+                - cat /etc/os-release
 
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/clabverter/test-fixtures/golden/simple/topo01.yaml
+++ b/clabverter/test-fixtures/golden/simple/topo01.yaml
@@ -34,6 +34,12 @@ spec:
           sros2:
             kind: nokia_sros
             image: nokia_sros:latest
+            healthcheck:
+              start-period: 5
+              interval: 1
+              test:
+                - CMD-SHELL
+                - cat /etc/os-release
 
         links:
           - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/controllers/topology/definition_test.go
+++ b/controllers/topology/definition_test.go
@@ -66,7 +66,9 @@ func TestDefinitionProcess(t *testing.T) {
 					"srl2": {
 						Name: "clabernetes-srl2",
 						Topology: &clabernetesutilcontainerlab.Topology{
-							Defaults: &clabernetesutilcontainerlab.NodeDefinition{Ports: []string{}},
+							Defaults: &clabernetesutilcontainerlab.NodeDefinition{
+								Ports: []string{},
+							},
 							Nodes: map[string]*clabernetesutilcontainerlab.NodeDefinition{
 								"srl2": {
 									Ports: []string{},

--- a/controllers/topology/definition_test.go
+++ b/controllers/topology/definition_test.go
@@ -43,6 +43,14 @@ func TestDefinitionProcess(t *testing.T) {
         srl2:
           kind: srl
           image: ghcr.io/nokia/srlinux
+          healthcheck:
+            test:
+              - CMD-SHELL
+              - cat /etc/os-release
+            start-period: 3
+            retries: 1
+            interval: 5
+            timeout: 2
       links:
         - endpoints: ["srl1:e1-1", "srl2:e1-1"]
         - endpoints: ["srl1:e3-3", "host:eth3-3"]
@@ -55,7 +63,26 @@ func TestDefinitionProcess(t *testing.T) {
 				ResolvedHashes: clabernetesapisv1alpha1.ReconcileHashes{},
 				ResolvedConfigs: map[string]*clabernetesutilcontainerlab.Config{
 					"srl1": {},
-					"srl2": {},
+					"srl2": {
+						Name: "clabernetes-srl2",
+						Topology: &clabernetesutilcontainerlab.Topology{
+							Defaults: &clabernetesutilcontainerlab.NodeDefinition{Ports: []string{}},
+							Nodes: map[string]*clabernetesutilcontainerlab.NodeDefinition{
+								"srl2": {
+									Ports: []string{},
+									Kind:  "srl",
+									Image: "ghcr.io/nokia/srlinux",
+									Healthcheck: &clabernetesutilcontainerlab.HealthcheckConfig{
+										Test:        []string{"CMD-SHELL", "cat /etc/os-release"},
+										StartPeriod: 3,
+										Retries:     1,
+										Interval:    5,
+										Timeout:     2,
+									},
+								},
+							},
+						},
+					},
 				},
 				ResolvedTunnels: map[string][]*clabernetesapisv1alpha1.PointToPointTunnel{
 					"srl1": {},

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
@@ -238,7 +238,17 @@
                         "Extras": null,
                         "WaitFor": null,
                         "DNS": null,
-                        "Certificate": null
+                        "Certificate": null,
+                        "Healthcheck": {
+                            "Test": [
+                                "CMD-SHELL",
+                                "cat /etc/os-release"
+                            ],
+                            "StartPeriod": 3,
+                            "Retries": 1,
+                            "Interval": 5,
+                            "Timeout": 2                        
+                    }
                     }
                 },
                 "Links": [

--- a/util/containerlab/topology_test.go
+++ b/util/containerlab/topology_test.go
@@ -4,10 +4,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
+	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
 	"gopkg.in/yaml.v3"
-
-	clab "github.com/srl-labs/clabernetes/util/containerlab"
 )
 
 func TestLoadContainerlabConfigFromString(t *testing.T) {
@@ -45,13 +43,13 @@ topology:
         start-period: 3
         retries: 1
         interval: 5
-        timeout: 2		
+        timeout: 2
 `,
 		},
 	}
 
 	for _, testCase := range cases {
-		_, err := clab.LoadContainerlabConfig(testCase.config)
+		_, err := clabernetesutilcontainerlab.LoadContainerlabConfig(testCase.config)
 		if err != nil {
 			t.Errorf("Unable to load containerlab config: %s", err)
 		}
@@ -60,7 +58,7 @@ topology:
 
 func TestLoadContainerlabConfigFromConfigObjects(t *testing.T) {
 	cases := []struct {
-		config *clab.Config
+		config *clabernetesutilcontainerlab.Config
 	}{
 		{
 			config: getMinimalValidConfigObject(),
@@ -76,7 +74,7 @@ func TestLoadContainerlabConfigFromConfigObjects(t *testing.T) {
 			t.Fatalf("Marshal error: %v", err)
 		}
 
-		cfg, err := clab.LoadContainerlabConfig(string(marshaled))
+		cfg, err := clabernetesutilcontainerlab.LoadContainerlabConfig(string(marshaled))
 		if err != nil {
 			t.Errorf("Unable to load containerlab config: %s", err)
 		}
@@ -85,19 +83,19 @@ func TestLoadContainerlabConfigFromConfigObjects(t *testing.T) {
 			t.Errorf("Configs not equal (-got +want):\n%s", diff)
 		}
 	}
-
 }
 
-func getMinimalValidConfigObjectWithFullHealthcheck() *clab.Config {
-	config := &clab.Config{Name: "minimalValidConfig"}
-	config.Topology = &clab.Topology{
-		Defaults: &clab.NodeDefinition{Ports: []string{}},
-		Nodes:    make(map[string]*clab.NodeDefinition)}
-	node := &clab.NodeDefinition{
+func getMinimalValidConfigObjectWithFullHealthcheck() *clabernetesutilcontainerlab.Config {
+	config := &clabernetesutilcontainerlab.Config{Name: "minimalValidConfig"}
+	config.Topology = &clabernetesutilcontainerlab.Topology{
+		Defaults: &clabernetesutilcontainerlab.NodeDefinition{Ports: []string{}},
+		Nodes:    make(map[string]*clabernetesutilcontainerlab.NodeDefinition),
+	}
+	node := &clabernetesutilcontainerlab.NodeDefinition{
 		Ports: []string{},
 		Kind:  "srl",
 		Image: "ghcr.io/nokia/srlinux",
-		Healthcheck: &clab.HealthcheckConfig{
+		Healthcheck: &clabernetesutilcontainerlab.HealthcheckConfig{
 			Test:        []string{"CMD-SHELL", "cat /etc/os-release"},
 			StartPeriod: 5,
 			Retries:     2,
@@ -106,22 +104,25 @@ func getMinimalValidConfigObjectWithFullHealthcheck() *clab.Config {
 		},
 	}
 	config.Topology.Nodes["srl1"] = node
+
 	return config
 }
 
-func getMinimalValidConfigObject() *clab.Config {
-	config := &clab.Config{Name: "minimalValidConfigWithFullHealthCheck"}
-	config.Topology = &clab.Topology{
-		Defaults: &clab.NodeDefinition{Ports: []string{}},
-		Nodes:    make(map[string]*clab.NodeDefinition)}
-	node := &clab.NodeDefinition{
+func getMinimalValidConfigObject() *clabernetesutilcontainerlab.Config {
+	config := &clabernetesutilcontainerlab.Config{Name: "minimalValidConfigWithFullHealthCheck"}
+	config.Topology = &clabernetesutilcontainerlab.Topology{
+		Defaults: &clabernetesutilcontainerlab.NodeDefinition{Ports: []string{}},
+		Nodes:    make(map[string]*clabernetesutilcontainerlab.NodeDefinition),
+	}
+	node := &clabernetesutilcontainerlab.NodeDefinition{
 		Ports: []string{},
 		Kind:  "srl",
 		Image: "ghcr.io/nokia/srlinux",
-		Healthcheck: &clab.HealthcheckConfig{
+		Healthcheck: &clabernetesutilcontainerlab.HealthcheckConfig{
 			Test: []string{"CMD-SHELL", "cat /etc/os-release"},
 		},
 	}
 	config.Topology.Nodes["srl1"] = node
+
 	return config
 }

--- a/util/containerlab/topology_test.go
+++ b/util/containerlab/topology_test.go
@@ -1,0 +1,127 @@
+package containerlab_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"gopkg.in/yaml.v3"
+
+	clab "github.com/srl-labs/clabernetes/util/containerlab"
+)
+
+func TestLoadContainerlabConfigFromString(t *testing.T) {
+	cases := []struct {
+		config string
+	}{
+		{
+			config: `
+name: topo01
+
+topology:
+  nodes:
+    srl1:
+      kind: srl
+      image: ghcr.io/nokia/srlinux
+      healthcheck:
+        test:
+          - CMD-SHELL
+          - cat /etc/os-release
+`,
+		},
+		{
+			config: `
+name: topo02
+
+topology:
+  nodes:
+    srl2:
+      kind: srl
+      image: ghcr.io/nokia/srlinux
+      healthcheck:
+        test:
+          - CMD-SHELL
+          - cat /etc/os-release
+        start-period: 3
+        retries: 1
+        interval: 5
+        timeout: 2		
+`,
+		},
+	}
+
+	for _, testCase := range cases {
+		_, err := clab.LoadContainerlabConfig(testCase.config)
+		if err != nil {
+			t.Errorf("Unable to load containerlab config: %s", err)
+		}
+	}
+}
+
+func TestLoadContainerlabConfigFromConfigObjects(t *testing.T) {
+	cases := []struct {
+		config *clab.Config
+	}{
+		{
+			config: getMinimalValidConfigObject(),
+		},
+		{
+			config: getMinimalValidConfigObjectWithFullHealthcheck(),
+		},
+	}
+
+	for _, testCase := range cases {
+		marshaled, err := yaml.Marshal(testCase.config)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+
+		cfg, err := clab.LoadContainerlabConfig(string(marshaled))
+		if err != nil {
+			t.Errorf("Unable to load containerlab config: %s", err)
+		}
+
+		if diff := cmp.Diff(testCase.config.Topology, cfg.Topology); diff != "" {
+			t.Errorf("Configs not equal (-got +want):\n%s", diff)
+		}
+	}
+
+}
+
+func getMinimalValidConfigObjectWithFullHealthcheck() *clab.Config {
+	config := &clab.Config{Name: "minimalValidConfig"}
+	config.Topology = &clab.Topology{
+		Defaults: &clab.NodeDefinition{Ports: []string{}},
+		Nodes:    make(map[string]*clab.NodeDefinition)}
+	node := &clab.NodeDefinition{
+		Ports: []string{},
+		Kind:  "srl",
+		Image: "ghcr.io/nokia/srlinux",
+		Healthcheck: &clab.HealthcheckConfig{
+			Test:        []string{"CMD-SHELL", "cat /etc/os-release"},
+			StartPeriod: 5,
+			Retries:     2,
+			Interval:    1,
+			Timeout:     3,
+		},
+	}
+	config.Topology.Nodes["srl1"] = node
+	return config
+}
+
+func getMinimalValidConfigObject() *clab.Config {
+	config := &clab.Config{Name: "minimalValidConfigWithFullHealthCheck"}
+	config.Topology = &clab.Topology{
+		Defaults: &clab.NodeDefinition{Ports: []string{}},
+		Nodes:    make(map[string]*clab.NodeDefinition)}
+	node := &clab.NodeDefinition{
+		Ports: []string{},
+		Kind:  "srl",
+		Image: "ghcr.io/nokia/srlinux",
+		Healthcheck: &clab.HealthcheckConfig{
+			Test: []string{"CMD-SHELL", "cat /etc/os-release"},
+		},
+	}
+	config.Topology.Nodes["srl1"] = node
+	return config
+}

--- a/util/containerlab/types.go
+++ b/util/containerlab/types.go
@@ -174,6 +174,8 @@ type NodeDefinition struct {
 	DNS *DNSConfig `yaml:"dns,omitempty"`
 	// Certificate Configuration
 	Certificate *CertificateConfig `yaml:"certificate,omitempty"`
+	// Healthcheck configuration
+	Healthcheck *HealthcheckConfig `yaml:"healthcheck,omitempty"`
 }
 
 // ConfigDispatcher represents the config of a configuration machine
@@ -223,4 +225,18 @@ type LinkConfig struct {
 	Labels    map[string]string      `yaml:"labels,omitempty"`
 	Vars      map[string]interface{} `yaml:"vars,omitempty"`
 	MTU       int                    `yaml:"mtu,omitempty"`
+}
+
+// HealthcheckConfig represents healthcheck options a node has.
+type HealthcheckConfig struct {
+	// Test: the command to run to check the health of the container
+	Test []string `yaml:"test,omitempty"`
+	// StartPeriod: the time in seconds to wait for the container to bootstrap before running the first health check
+	StartPeriod int `yaml:"start-period,omitempty"`
+	// Retries: the number of consecutive healthcheck failures needed to report the container as unhealthy.
+	Retries int `yaml:"retries,omitempty"`
+	// Interval: the time interval between the health checks in seconds
+	Interval int `yaml:"interval,omitempty"`
+	// Timeout: the time in seconds to wait for a single health check operation to complete.
+	Timeout int `yaml:"timeout,omitempty"`
 }

--- a/util/containerlab/types.go
+++ b/util/containerlab/types.go
@@ -231,9 +231,11 @@ type LinkConfig struct {
 type HealthcheckConfig struct {
 	// Test: the command to run to check the health of the container
 	Test []string `yaml:"test"`
-	// StartPeriod: the time in seconds to wait for the container to bootstrap before running the first health check
+	// StartPeriod: the time in seconds to wait for the container to bootstrap before running the
+	// first health check
 	StartPeriod int `yaml:"start-period,omitempty"`
-	// Retries: the number of consecutive healthcheck failures needed to report the container as unhealthy.
+	// Retries: the number of consecutive healthcheck failures needed to report the container as
+	// unhealthy.
 	Retries int `yaml:"retries,omitempty"`
 	// Interval: the time interval between the health checks in seconds
 	Interval int `yaml:"interval,omitempty"`

--- a/util/containerlab/types.go
+++ b/util/containerlab/types.go
@@ -230,7 +230,7 @@ type LinkConfig struct {
 // HealthcheckConfig represents healthcheck options a node has.
 type HealthcheckConfig struct {
 	// Test: the command to run to check the health of the container
-	Test []string `yaml:"test,omitempty"`
+	Test []string `yaml:"test"`
 	// StartPeriod: the time in seconds to wait for the container to bootstrap before running the first health check
 	StartPeriod int `yaml:"start-period,omitempty"`
 	// Retries: the number of consecutive healthcheck failures needed to report the container as unhealthy.


### PR DESCRIPTION
Goal is to propagate the containerlab healthchecks in Clabernetes.

Changes:
- added Healthcheck to types.go

Tests:
- added a topology_test.go with unit tests for LoadContainerlabConfig
- updated unit test in definition_test.go to support healthcheck
- updated clabverter test-fixtures data files (for non-regression purposes)