### PR TITLE
Update deployment.yaml - removing leading spaces

### DIFF
--- a/charts/clabernetes/templates/deployment.yaml
+++ b/charts/clabernetes/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       {{- if .Values.manager.affinity }}
       affinity:
-        {{ toYaml .Values.manager.affinity | indent 8 }}
+{{ toYaml .Values.manager.affinity | indent 8 }}
       {{- else if (ge (int .Values.manager.replicaCount) 2) }}
       affinity:
         podAntiAffinity:
@@ -210,7 +210,7 @@ spec:
     spec:
       {{- if $.Values.ui.affinity }}
       affinity:
-        {{ toYaml $.Values.ui.affinity | indent 8 }}
+{{ toYaml $.Values.ui.affinity | indent 8 }}
       {{- else if (ge (int $.Values.ui.replicaCount) 2) }}
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
The leading spaces in these 2 lines are breaking (yaml formatting) the helm deployment only if custom affinity values are passed via values.yaml. These spaces are adding the 8 spaces + leading spaces