### PR TITLE
feat: limit ClusterRole permissions using RBAC

### DIFF
--- a/charts/clabernetes/templates/clusterrole.yaml
+++ b/charts/clabernetes/templates/clusterrole.yaml
@@ -49,6 +49,10 @@ rules:
       - persistentvolumeclaims
       - serviceaccounts
     verbs:
+    {{- if .Values.manager.restrictedRBAC.enabled }}
+      - list
+      - watch
+    {{- else }}
       - get
       - list
       - create
@@ -56,6 +60,7 @@ rules:
       - delete
       - patch
       - watch
+    {{- end }}
   - apiGroups:
       - coordination.k8s.io
     resources:
@@ -73,6 +78,10 @@ rules:
     resources:
       - deployments
     verbs:
+    {{- if .Values.manager.restrictedRBAC.enabled }}
+      - list
+      - watch
+    {{- else }}
       - get
       - list
       - create
@@ -80,11 +89,16 @@ rules:
       - delete
       - patch
       - watch
+    {{- end }}
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings
     verbs:
+    {{- if .Values.manager.restrictedRBAC.enabled }}
+      - list
+      - watch
+    {{- else }}
       - get
       - list
       - create
@@ -92,6 +106,7 @@ rules:
       - delete
       - patch
       - watch
+    {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/clabernetes/templates/restricted-rbac.yaml
+++ b/charts/clabernetes/templates/restricted-rbac.yaml
@@ -1,0 +1,212 @@
+{{- if .Values.manager.restrictedRBAC.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    revision: "{{ .Release.Revision }}"
+    clabernetes/app: {{ .Values.appName }}
+    clabernetes/name: "{{ .Values.appName }}-restricted-role"
+    clabernetes/component: role
+    {{- if .Values.globalLabels }}
+{{ .Values.globalLabels | toYaml | indent 4 }}
+    {{- end }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ .Values.globalAnnotations | toYaml | indent 4 }}
+  {{- end }}
+  name: "{{ .Values.appName }}-restricted-role"
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+      - configmaps
+      - services
+      - pods
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Values.appName }}-restricted-role-binding"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    revision: "{{ .Release.Revision }}"
+    clabernetes/app: {{ .Values.appName }}
+    clabernetes/name: "{{ .Values.appName }}-restricted-role-binding"
+    clabernetes/component: role-binding
+    {{- if .Values.globalLabels }}
+{{ .Values.globalLabels | toYaml | indent 4 }}
+    {{- end }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ .Values.globalAnnotations | toYaml | indent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: "{{ .Values.appName }}-service-account"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: "{{ .Values.appName }}-restricted-role"
+  apiGroup: rbac.authorization.k8s.io
+---
+{{- range .Values.manager.restrictedRBAC.targetNamespaces }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    revision: "{{ $.Release.Revision }}"
+    clabernetes/app: {{ $.Values.appName }}
+    clabernetes/name: "{{ $.Values.appName }}-launcher-namespace"
+    clabernetes/component: namespace
+    pod-security.kubernetes.io/enforce: privileged
+    {{- if $.Values.globalLabels }}
+{{ $.Values.globalLabels | toYaml | indent 4 }}
+    {{- end }}
+  {{- if $.Values.globalAnnotations }}
+  annotations:
+{{ $.Values.globalAnnotations | toYaml | indent 4 }}
+  {{- end }}
+  name: {{ . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    revision: "{{ $.Release.Revision }}"
+    clabernetes/app: {{ $.Values.appName }}
+    clabernetes/name: "{{ $.Values.appName }}-restricted-role"
+    clabernetes/component: role
+    {{- if $.Values.globalLabels }}
+{{ $.Values.globalLabels | toYaml | indent 4 }}
+    {{- end }}
+  {{- if $.Values.globalAnnotations }}
+  annotations:
+{{ $.Values.globalAnnotations | toYaml | indent 4 }}
+  {{- end }}
+  name: "{{ $.Values.appName }}-restricted-role"
+  namespace: {{ . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+      - configmaps
+      - services
+      - pods
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $.Values.appName }}-restricted-role-binding"
+  namespace: {{ . }}
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    revision: "{{ $.Release.Revision }}"
+    clabernetes/app: {{ $.Values.appName }}
+    clabernetes/name: "{{ $.Values.appName }}-restricted-role-binding"
+    clabernetes/component: role-binding
+    {{- if $.Values.globalLabels }}
+{{ $.Values.globalLabels | toYaml | indent 4 }}
+    {{- end }}
+  {{- if $.Values.globalAnnotations }}
+  annotations:
+{{ $.Values.globalAnnotations | toYaml | indent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: "{{ $.Values.appName }}-service-account"
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: "{{ $.Values.appName }}-restricted-role"
+  apiGroup: rbac.authorization.k8s.io
+---
+{{- end }}
+{{- end }}

--- a/charts/clabernetes/values.schema.json
+++ b/charts/clabernetes/values.schema.json
@@ -51,6 +51,20 @@
         },
         "affinity": {
           "type": "object"
+        },
+        "restrictedRBAC": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "targetNamespaces": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/clabernetes/values.yaml
+++ b/charts/clabernetes/values.yaml
@@ -46,6 +46,16 @@ manager:
   # pod affinity settings, directly inserted into manager deployment spec; if not provided basic
   # common-sense anti-affinity is applied.
   affinity: {}
+  # restrictedRBAC enables a more restricted RBAC setup for the manager. When enabled, the
+  # ClusterRole given to the manager's ServiceAccount is more limited, and a Role and
+  # RoleBinding are created in each of the namespaces listed in `targetNamespaces` below to
+  # grant extra permissions.
+  restrictedRBAC:
+    enabled: false
+    targetNamespaces:
+      - c9s-lab1
+      - c9s-lab2
+      - c9s-lab3
 
 #
 # global config


### PR DESCRIPTION
This PR enables an optional field `manager.restrictedRBAC` that lets users restrict the controller's overly broad permissions to certain namespaces only. 

This is handled entirely in Helm for now (Alternative: https://sdk.operatorframework.io/docs/building-operators/golang/operator-scope/). 

Closes issue #217 