### PR TITLE
fix: delete existing vxlan interface on start

### DIFF
--- a/launcher/connectivity/vxlan.go
+++ b/launcher/connectivity/vxlan.go
@@ -115,6 +115,7 @@ func (m *vxlanManager) runContainerlabVxlanToolsCreate(
 
 	vxlanInterfaceName := fmt.Sprintf("%s-%s", localNodeName, cntLink)
 	m.logger.Debugf("Attempting to delete existing vxlan interface '%s'", vxlanInterfaceName)
+
 	err = m.runContainerlabVxlanToolsDelete(m.ctx, localNodeName, cntLink)
 	if err != nil {
 		m.logger.Warnf(


### PR DESCRIPTION
Delete the existing vxlan interface before an attempt to create the (new) interface is made. Fixes #219.