### PR TITLE
feat: add OpenShift support

### DIFF
--- a/charts/clabernetes/templates/openshift.yaml
+++ b/charts/clabernetes/templates/openshift.yaml
@@ -1,0 +1,33 @@
+{{- if and (.Capabilities.APIVersions.Has "security.openshift.io/v1") .Values.manager.restrictedRBAC.enabled -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: anyuid-scc-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- kind: ServiceAccount
+  name: "{{ .Values.appName }}-service-account"
+  namespace: {{ .Release.Namespace }}
+---
+{{- range .Values.manager.restrictedRBAC.targetNamespaces -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: privileged-scc-rolebinding
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: clabernetes-launcher-service-account
+  namespace: {{ . }}
+---
+{{- end -}}
+{{- end -}}

--- a/charts/clabernetes/values.yaml
+++ b/charts/clabernetes/values.yaml
@@ -50,6 +50,7 @@ manager:
   # ClusterRole given to the manager's ServiceAccount is more limited, and a Role and
   # RoleBinding are created in each of the namespaces listed in `targetNamespaces` below to
   # grant extra permissions.
+  # This is needed on OpenShift clusters to prevent default SCC restrictions.
   restrictedRBAC:
     enabled: false
     targetNamespaces: []


### PR DESCRIPTION
This PR uses the existing restrictedRBAC field(s) to ensure that RoleBindings for the relevant SecurityContextConstraints ClusterRoles (`anyuid` for the manager pod and `privileged` for the other container images) are created. This fixes #221.