### PR TITLE
Proxy support

### DIFF
--- a/.mk/tools.makefile
+++ b/.mk/tools.makefile
@@ -28,7 +28,8 @@ endif
 
 ## curl wrapper used by the download helpers
 ## ----------------------------------------------------------------------------|
-CURL_OPTS ?= --location --silent --fail --show-error
+# retries paper over transient network hiccups (flaky corporate proxies etc.)
+CURL_OPTS ?= --location --silent --fail --show-error --retry 3 --retry-delay 1 --retry-all-errors
 CURL := curl $(CURL_OPTS)
 
 ## Download helpers

--- a/.mk/try-c9s.makefile
+++ b/.mk/try-c9s.makefile
@@ -51,10 +51,10 @@ TRY_C9S_HELM_WAIT_ARG := $(if $(filter v4%,$(HELM_VERSION)),--wait=legacy,--wait
 ## When the host has HTTP(S)_PROXY set, the launcher pods need those vars too so
 ## their docker daemon (and nerdctl during image pull through) can pull images.
 ## They are passed via the chart's globalConfig.deployment.extraEnv. NO_PROXY is
-## extended with the KinD service/pod subnets and cluster-local names so that
-## in-cluster traffic (kube api, etc.) never hits the proxy. The extraEnv json
-## is rendered with yq from the env vars so no quoting/escaping shenanigans.
-TRY_C9S_NO_PROXY_EXTRA := 10.96.0.0/16,10.244.0.0/16,.svc,.svc.cluster.local,localhost,127.0.0.1
+## extended with the discovered KinD service/pod subnets and cluster-local names
+## so that in-cluster traffic (kube api, etc.) never hits the proxy. The extraEnv
+## json is rendered with yq from the env vars so no quoting/escaping shenanigans.
+TRY_C9S_NO_PROXY_EXTRA := .svc,.svc.cluster.local,localhost,127.0.0.1
 
 # expands to a `--set-json globalConfig.deployment.extraEnv=[...]` helm arg (or
 # nothing when no proxy is set); intended for use inside a recipe shell.
@@ -63,8 +63,17 @@ define try-c9s-proxy-helm-args
 	https_proxy_val="$${HTTPS_PROXY:-$$https_proxy}"; \
 	proxy_helm_args=""; \
 	if [ -n "$$http_proxy_val" ] || [ -n "$$https_proxy_val" ]; then \
+		pod_cidrs=$$($(KUBECTL) get nodes -o json | \
+			$(YQ) -r '[.items[].spec.podCIDRs[]] | join(",")'); \
+		service_cidrs=$$($(KUBECTL) -n kube-system get configmap kubeadm-config \
+			-o jsonpath='{.data.ClusterConfiguration}' | \
+			$(YQ) -r '.networking.serviceSubnet // ""'); \
+		if [ -z "$$pod_cidrs" ] || [ -z "$$service_cidrs" ]; then \
+			echo "--> TRY-C9S: failed to discover KinD pod/service CIDRs"; \
+			exit 1; \
+		fi; \
 		no_proxy_val="$${NO_PROXY:-$$no_proxy}"; \
-		no_proxy_val="$${no_proxy_val:+$$no_proxy_val,}$(TRY_C9S_NO_PROXY_EXTRA)"; \
+		no_proxy_val="$${no_proxy_val:+$$no_proxy_val,}$$service_cidrs,$$pod_cidrs,$(TRY_C9S_NO_PROXY_EXTRA)"; \
 		extra_env_json=$$( \
 			C9S_HTTP_PROXY="$$http_proxy_val" \
 			C9S_HTTPS_PROXY="$$https_proxy_val" \

--- a/.mk/try-c9s.makefile
+++ b/.mk/try-c9s.makefile
@@ -46,6 +46,44 @@ YQ_SRC ?= https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(O
 TRY_C9S_CHART_VERSION_ARG := $(if $(TRY_C9S_CHART_VERSION),--version $(TRY_C9S_CHART_VERSION),)
 TRY_C9S_HELM_WAIT_ARG := $(if $(filter v4%,$(HELM_VERSION)),--wait=legacy,--wait)
 
+## Proxy support
+## ----------------------------------------------------------------------------|
+## When the host has HTTP(S)_PROXY set, the launcher pods need those vars too so
+## their docker daemon (and nerdctl during image pull through) can pull images.
+## They are passed via the chart's globalConfig.deployment.extraEnv. NO_PROXY is
+## extended with the KinD service/pod subnets and cluster-local names so that
+## in-cluster traffic (kube api, etc.) never hits the proxy. The extraEnv json
+## is rendered with yq from the env vars so no quoting/escaping shenanigans.
+TRY_C9S_NO_PROXY_EXTRA := 10.96.0.0/16,10.244.0.0/16,.svc,.svc.cluster.local,localhost,127.0.0.1
+
+# expands to a `--set-json globalConfig.deployment.extraEnv=[...]` helm arg (or
+# nothing when no proxy is set); intended for use inside a recipe shell.
+define try-c9s-proxy-helm-args
+	http_proxy_val="$${HTTP_PROXY:-$$http_proxy}"; \
+	https_proxy_val="$${HTTPS_PROXY:-$$https_proxy}"; \
+	proxy_helm_args=""; \
+	if [ -n "$$http_proxy_val" ] || [ -n "$$https_proxy_val" ]; then \
+		no_proxy_val="$${NO_PROXY:-$$no_proxy}"; \
+		no_proxy_val="$${no_proxy_val:+$$no_proxy_val,}$(TRY_C9S_NO_PROXY_EXTRA)"; \
+		extra_env_json=$$( \
+			C9S_HTTP_PROXY="$$http_proxy_val" \
+			C9S_HTTPS_PROXY="$$https_proxy_val" \
+			C9S_NO_PROXY="$$no_proxy_val" \
+			$(YQ) -n -o=json -I=0 \
+				'[ \
+					{"name": "HTTP_PROXY", "value": strenv(C9S_HTTP_PROXY)}, \
+					{"name": "http_proxy", "value": strenv(C9S_HTTP_PROXY)}, \
+					{"name": "HTTPS_PROXY", "value": strenv(C9S_HTTPS_PROXY)}, \
+					{"name": "https_proxy", "value": strenv(C9S_HTTPS_PROXY)}, \
+					{"name": "NO_PROXY", "value": strenv(C9S_NO_PROXY)}, \
+					{"name": "no_proxy", "value": strenv(C9S_NO_PROXY)} \
+				] | map(select(.value != ""))' \
+		); \
+		proxy_helm_args="--set-json globalConfig.deployment.extraEnv=$$extra_env_json"; \
+		echo "--> TRY-C9S: proxy env detected, passing proxy config to launcher pods"; \
+	fi
+endef
+
 .PHONY: try-c9s
 try-c9s: try-c9s-expose ## Launch published clabernetes in KinD and apply a sample topology
 	@echo "--> TRY-C9S: clabernetes is ready to try"
@@ -141,14 +179,16 @@ try-c9s-metallb: try-c9s-cluster | $(TRY_C9S_STATE_DIR)
 .PHONY: try-c9s-install
 try-c9s-install: try-c9s-metallb
 	@echo "--> TRY-C9S: installing published clabernetes chart"
-	@$(HELM) upgrade --install clabernetes $(TRY_C9S_CHART) $(TRY_C9S_CHART_VERSION_ARG) \
+	@$(call try-c9s-proxy-helm-args); \
+	$(HELM) upgrade --install clabernetes $(TRY_C9S_CHART) $(TRY_C9S_CHART_VERSION_ARG) \
 		--namespace $(TRY_C9S_NAMESPACE) \
 		--create-namespace \
 		$(TRY_C9S_HELM_WAIT_ARG) \
 		--timeout $(TRY_C9S_TIMEOUT) \
 		--set ui.ingress.enabled=false \
 		--set manager.replicaCount=1 \
-		--set ui.replicaCount=1
+		--set ui.replicaCount=1 \
+		$$proxy_helm_args
 	@$(KUBECTL) -n $(TRY_C9S_NAMESPACE) rollout status deploy/clabernetes-manager --timeout=$(TRY_C9S_TIMEOUT)
 	@$(KUBECTL) -n $(TRY_C9S_NAMESPACE) rollout status deploy/clabernetes-ui --timeout=$(TRY_C9S_TIMEOUT)
 

--- a/charts/clabernetes/values.yaml
+++ b/charts/clabernetes/values.yaml
@@ -162,6 +162,8 @@ globalConfig:
 
     # extraEnv is a list of k8scorev1.EnvVar that will be set on any launcher pods. Note that any
     # configured global config env vars will be ignored if a Topology has an extraEnv config.
+    # This is also the place to set HTTP_PROXY/HTTPS_PROXY/NO_PROXY if your cluster needs a proxy
+    # to pull images -- see docs/guides/image-pull.md for details.
     extraEnv: []
 
   # name is the global setting that governs a Topology's "naming" field when set to "global".

--- a/constants/env.go
+++ b/constants/env.go
@@ -20,6 +20,29 @@ const (
 )
 
 const (
+	// HTTPProxyEnv is the standard env var for proxying http traffic. If set on a launcher pod
+	// (i.e. via the topology or global config extra env vars) it is passed to the launcher's
+	// docker daemon so images can be pulled through the proxy.
+	HTTPProxyEnv = "HTTP_PROXY"
+
+	// HTTPProxyEnvLower is the lowercase variant of HTTPProxyEnv.
+	HTTPProxyEnvLower = "http_proxy"
+
+	// HTTPSProxyEnv is the standard env var for proxying https traffic, see also HTTPProxyEnv.
+	HTTPSProxyEnv = "HTTPS_PROXY"
+
+	// HTTPSProxyEnvLower is the lowercase variant of HTTPSProxyEnv.
+	HTTPSProxyEnvLower = "https_proxy"
+
+	// NoProxyEnv is the standard env var holding hosts/cidrs/domains that should *not* be
+	// proxied, see also HTTPProxyEnv.
+	NoProxyEnv = "NO_PROXY"
+
+	// NoProxyEnvLower is the lowercase variant of NoProxyEnv.
+	NoProxyEnvLower = "no_proxy"
+)
+
+const (
 	// GitHubTokenEnv is the env var that holds (optionally of course) a GitHub token -- this is
 	// useful for the clabverter tool as well as the launcher where we *may* need to use the
 	// GitHub api to list contents of a directory (this is specifically for dealing with large files

--- a/docs/guides/image-pull.md
+++ b/docs/guides/image-pull.md
@@ -159,6 +159,51 @@ spec:
 
 **Note:** This is ignored if `dockerDaemonConfig` is set (configure in daemon.json instead).
 
+## HTTP(S) Proxy Support
+
+If your cluster reaches the internet through an HTTP(S) proxy, set the standard proxy env vars
+on the launcher pods -- either per topology or globally:
+
+```yaml
+spec:
+  deployment:
+    extraEnv:
+      - name: HTTP_PROXY
+        value: http://proxy.example.com:8080
+      - name: HTTPS_PROXY
+        value: http://proxy.example.com:8080
+      - name: NO_PROXY
+        value: 10.96.0.0/16,10.244.0.0/16,.svc,.svc.cluster.local,localhost,127.0.0.1
+```
+
+Or for all topologies via the Config CRD (or the `globalConfig.deployment.extraEnv` helm value):
+
+```yaml
+apiVersion: clabernetes.containerlab.dev/v1alpha1
+kind: Config
+metadata:
+  name: clabernetes
+spec:
+  deployment:
+    extraEnv:
+      - name: HTTPS_PROXY
+        value: http://proxy.example.com:8080
+      # ...
+```
+
+**How it works:**
+- The launcher writes the proxy env vars into its Docker daemon config (`proxies` section), so
+  direct Docker pulls go through the proxy.
+- Pull-through mode also works: the pull pod uses the node CRI (configure your CRI for the proxy
+  as usual, most distributions handle this already), and the launcher-side `nerdctl` operations
+  inherit the env vars.
+- The in-cluster Kubernetes API service address is automatically appended to `NO_PROXY` by the
+  launcher, so it never tries to reach the API through the proxy.
+
+**Note:** `NO_PROXY` should contain your cluster's service and pod CIDRs plus cluster-local DNS
+suffixes (see the example above -- adjust the CIDRs for your cluster). Proxy env vars are ignored
+if `dockerDaemonConfig` is set (configure `proxies` in your daemon.json instead).
+
 ## Global Configuration
 
 Set defaults in the Config CRD:

--- a/launcher/assets.go
+++ b/launcher/assets.go
@@ -1,8 +1,0 @@
-package launcher
-
-import "embed"
-
-// Assets is the embedded asset objects for the clabernetes launcher.
-//
-//go:embed assets/*
-var Assets embed.FS

--- a/launcher/assets/docker-daemon.json.template
+++ b/launcher/assets/docker-daemon.json.template
@@ -1,6 +1,0 @@
-{
-    "storage-driver": "{{ .StorageDriver }}",
-	"insecure-registries": [
-        {{ .InsecureRegistries }}
-	]
-}

--- a/launcher/clabernetes.go
+++ b/launcher/clabernetes.go
@@ -58,6 +58,8 @@ func StartClabernetes() {
 
 	ctx, cancel := clabernetesutil.SignalHandledContext(clabernetesLogger.Criticalf)
 
+	ensureKubeAPINotProxied()
+
 	clabernetesInstance = &clabernetes{
 		ctx:                   ctx,
 		cancel:                cancel,
@@ -155,13 +157,13 @@ func (c *clabernetes) setup() {
 	}
 
 	if daemonConfigExists() {
-		c.logger.Infof("%q exists, skipping insecure registries", dockerDaemonConfig)
+		c.logger.Infof("%q exists, skipping docker daemon config", dockerDaemonConfig)
 	} else {
-		c.logger.Debug("configure insecure registries if requested...")
+		c.logger.Debug("configure docker daemon (insecure registries/proxies) if requested...")
 
-		err := handleInsecureRegistries()
+		err := handleDockerDaemonConfig()
 		if err != nil {
-			c.logger.Fatalf("failed configuring insecure docker registries, err: %s", err)
+			c.logger.Fatalf("failed configuring docker daemon, err: %s", err)
 		}
 	}
 

--- a/launcher/docker.go
+++ b/launcher/docker.go
@@ -1,19 +1,19 @@
 package launcher
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
-	"text/template"
 	"time"
 
 	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
 	claberneteserrors "github.com/srl-labs/clabernetes/errors"
 	claberneteslogging "github.com/srl-labs/clabernetes/logging"
+	clabernetesutil "github.com/srl-labs/clabernetes/util"
 )
 
 const (
@@ -28,27 +28,57 @@ func daemonConfigExists() bool {
 	return err == nil
 }
 
-func handleInsecureRegistries() error {
-	insecureRegistries := os.Getenv(clabernetesconstants.LauncherInsecureRegistries)
+type daemonConfig struct {
+	StorageDriver      string               `json:"storage-driver"`
+	InsecureRegistries []string             `json:"insecure-registries,omitempty"`
+	Proxies            *daemonProxiesConfig `json:"proxies,omitempty"`
+}
 
-	if insecureRegistries == "" {
+type daemonProxiesConfig struct {
+	HTTPProxy  string `json:"http-proxy,omitempty"`
+	HTTPSProxy string `json:"https-proxy,omitempty"`
+	NoProxy    string `json:"no-proxy,omitempty"`
+}
+
+func getProxiesConfig() *daemonProxiesConfig {
+	httpProxy := clabernetesutil.GetEnvStrOrDefault(
+		clabernetesconstants.HTTPProxyEnv,
+		os.Getenv(clabernetesconstants.HTTPProxyEnvLower),
+	)
+	httpsProxy := clabernetesutil.GetEnvStrOrDefault(
+		clabernetesconstants.HTTPSProxyEnv,
+		os.Getenv(clabernetesconstants.HTTPSProxyEnvLower),
+	)
+	noProxy := clabernetesutil.GetEnvStrOrDefault(
+		clabernetesconstants.NoProxyEnv,
+		os.Getenv(clabernetesconstants.NoProxyEnvLower),
+	)
+
+	if httpProxy == "" && httpsProxy == "" {
 		return nil
 	}
 
-	splitRegistries := strings.Split(insecureRegistries, ",")
+	return &daemonProxiesConfig{
+		HTTPProxy:  httpProxy,
+		HTTPSProxy: httpsProxy,
+		NoProxy:    noProxy,
+	}
+}
 
-	quotedRegistries := make([]string, len(splitRegistries))
-
-	for idx, elem := range splitRegistries {
-		quotedRegistries[idx] = fmt.Sprintf("%q", elem)
+func handleDockerDaemonConfig() error {
+	config := daemonConfig{
+		StorageDriver: vfsStorageDriver,
+		Proxies:       getProxiesConfig(),
 	}
 
-	templateVars := struct {
-		StorageDriver      string
-		InsecureRegistries string
-	}{
-		StorageDriver:      vfsStorageDriver,
-		InsecureRegistries: strings.Join(quotedRegistries, ","),
+	insecureRegistries := os.Getenv(clabernetesconstants.LauncherInsecureRegistries)
+	if insecureRegistries != "" {
+		config.InsecureRegistries = strings.Split(insecureRegistries, ",")
+	}
+
+	if config.Proxies == nil && config.InsecureRegistries == nil {
+		// nothing to configure, leave the daemon config alone (unset)
+		return nil
 	}
 
 	// if the pod is privileged we can run w/ overlayfs instead of vfs which should
@@ -59,24 +89,17 @@ func handleInsecureRegistries() error {
 		os.Getenv(clabernetesconstants.LauncherPrivilegedEnv),
 		clabernetesconstants.True,
 	) {
-		templateVars.StorageDriver = overlayStorageDriver
+		config.StorageDriver = overlayStorageDriver
 	}
 
-	t, err := template.ParseFS(Assets, "assets/docker-daemon.json.template")
-	if err != nil {
-		return err
-	}
-
-	var rendered bytes.Buffer
-
-	err = t.Execute(&rendered, templateVars)
+	rendered, err := json.MarshalIndent(config, "", "    ")
 	if err != nil {
 		return err
 	}
 
 	err = os.WriteFile(
 		dockerDaemonConfig,
-		rendered.Bytes(),
+		rendered,
 		clabernetesconstants.PermissionsEveryoneReadWriteOwnerExecute,
 	)
 	if err != nil {

--- a/launcher/docker_test.go
+++ b/launcher/docker_test.go
@@ -1,0 +1,164 @@
+package launcher //nolint:testpackage // tests cover unexported docker daemon config helpers
+
+import (
+	"os"
+	"testing"
+
+	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
+)
+
+func TestGetProxiesConfig(t *testing.T) { //nolint:paralleltest // mutates env vars
+	tests := []struct {
+		name     string
+		env      map[string]string
+		expected *daemonProxiesConfig
+	}{
+		{
+			name:     "no-proxy-env",
+			env:      map[string]string{},
+			expected: nil,
+		},
+		{
+			name: "uppercase",
+			env: map[string]string{
+				clabernetesconstants.HTTPProxyEnv:  "http://proxy.example.com:8080",
+				clabernetesconstants.HTTPSProxyEnv: "http://proxy.example.com:8080",
+				clabernetesconstants.NoProxyEnv:    "localhost,10.0.0.0/8",
+			},
+			expected: &daemonProxiesConfig{
+				HTTPProxy:  "http://proxy.example.com:8080",
+				HTTPSProxy: "http://proxy.example.com:8080",
+				NoProxy:    "localhost,10.0.0.0/8",
+			},
+		},
+		{
+			name: "lowercase",
+			env: map[string]string{
+				clabernetesconstants.HTTPSProxyEnvLower: "http://proxy.example.com:8080",
+				clabernetesconstants.NoProxyEnvLower:    "localhost",
+			},
+			expected: &daemonProxiesConfig{
+				HTTPSProxy: "http://proxy.example.com:8080",
+				NoProxy:    "localhost",
+			},
+		},
+		{
+			name: "no-proxy-alone-is-ignored",
+			env: map[string]string{
+				clabernetesconstants.NoProxyEnv: "localhost",
+			},
+			expected: nil,
+		},
+	}
+
+	proxyEnvKeys := []string{
+		clabernetesconstants.HTTPProxyEnv,
+		clabernetesconstants.HTTPProxyEnvLower,
+		clabernetesconstants.HTTPSProxyEnv,
+		clabernetesconstants.HTTPSProxyEnvLower,
+		clabernetesconstants.NoProxyEnv,
+		clabernetesconstants.NoProxyEnvLower,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest // mutates env vars
+			for _, key := range proxyEnvKeys {
+				t.Setenv(key, "")
+
+				err := os.Unsetenv(key)
+				if err != nil {
+					t.Fatalf("failed unsetting env var %q, err: %s", key, err)
+				}
+			}
+
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			got := getProxiesConfig()
+
+			switch {
+			case tt.expected == nil:
+				if got != nil {
+					t.Fatalf("expected nil proxies config, got %+v", got)
+				}
+			case got == nil:
+				t.Fatalf("expected proxies config %+v, got nil", tt.expected)
+			case *got != *tt.expected:
+				t.Fatalf("expected proxies config %+v, got %+v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestEnsureKubeAPINotProxied(t *testing.T) { //nolint:paralleltest // mutates env vars
+	tests := []struct {
+		name            string
+		httpsProxy      string
+		noProxy         string
+		apiHost         string
+		expectedNoProxy string
+	}{
+		{
+			name:            "appends-api-host",
+			httpsProxy:      "http://proxy.example.com:8080",
+			noProxy:         "localhost",
+			apiHost:         "10.96.0.1",
+			expectedNoProxy: "localhost,10.96.0.1",
+		},
+		{
+			name:            "sets-when-empty",
+			httpsProxy:      "http://proxy.example.com:8080",
+			noProxy:         "",
+			apiHost:         "10.96.0.1",
+			expectedNoProxy: "10.96.0.1",
+		},
+		{
+			name:            "already-present",
+			httpsProxy:      "http://proxy.example.com:8080",
+			noProxy:         "localhost,10.96.0.1,example.com",
+			apiHost:         "10.96.0.1",
+			expectedNoProxy: "localhost,10.96.0.1,example.com",
+		},
+		{
+			name:            "no-proxy-configured-no-op",
+			httpsProxy:      "",
+			noProxy:         "localhost",
+			apiHost:         "10.96.0.1",
+			expectedNoProxy: "localhost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest // mutates env vars
+			for _, key := range []string{
+				clabernetesconstants.HTTPProxyEnv,
+				clabernetesconstants.HTTPProxyEnvLower,
+				clabernetesconstants.HTTPSProxyEnvLower,
+			} {
+				t.Setenv(key, "")
+
+				err := os.Unsetenv(key)
+				if err != nil {
+					t.Fatalf("failed unsetting env var %q, err: %s", key, err)
+				}
+			}
+
+			t.Setenv(clabernetesconstants.HTTPSProxyEnv, tt.httpsProxy)
+			t.Setenv(clabernetesconstants.NoProxyEnv, tt.noProxy)
+			t.Setenv(clabernetesconstants.NoProxyEnvLower, tt.noProxy)
+			t.Setenv("KUBERNETES_SERVICE_HOST", tt.apiHost)
+
+			ensureKubeAPINotProxied()
+
+			for _, key := range []string{
+				clabernetesconstants.NoProxyEnv,
+				clabernetesconstants.NoProxyEnvLower,
+			} {
+				if got := os.Getenv(key); got != tt.expectedNoProxy {
+					t.Fatalf("expected %s %q, got %q", key, tt.expectedNoProxy, got)
+				}
+			}
+		})
+	}
+}

--- a/launcher/proxy.go
+++ b/launcher/proxy.go
@@ -1,0 +1,42 @@
+package launcher
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
+)
+
+// ensureKubeAPINotProxied makes sure the in-cluster kubernetes api service address is never sent
+// through a configured proxy -- proxy env vars typically end up on launcher pods via the topology
+// (or global config) extra envs, and users setting those cannot reliably know the in-cluster
+// service address to exclude it themselves. must run before any http clients are built since the
+// stdlib caches the proxy env vars on first use.
+func ensureKubeAPINotProxied() {
+	if getProxiesConfig() == nil {
+		return
+	}
+
+	apiHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if apiHost == "" {
+		return
+	}
+
+	for _, key := range []string{
+		clabernetesconstants.NoProxyEnv,
+		clabernetesconstants.NoProxyEnvLower,
+	} {
+		current := os.Getenv(key)
+
+		switch {
+		case current == "":
+			_ = os.Setenv(key, apiHost)
+		case !strings.Contains(
+			fmt.Sprintf(",%s,", current),
+			fmt.Sprintf(",%s,", apiHost),
+		):
+			_ = os.Setenv(key, fmt.Sprintf("%s,%s", current, apiHost))
+		}
+	}
+}


### PR DESCRIPTION
## What this does
  
Running clabernetes behind a corporate proxy currently fails: launcher pods have no proxy configuration, so every way of getting a node image into the launcher's docker daemon breaks. Tested live behind a proxy-only network, the failure chain is:

1. image pull through: the launcher-side nerdctl re-pull times out (dial tcp ...:443: i/o timeout) since the launcher pod has no proxy env
2. the CRI export then fails on containerds with discard_unpacked_layers = true (e.g. KinD), where the re-pull is mandatory
3. the fallback direct pull via containerlab fails too (Get "https://ghcr.io/v2/": context deadline exceeded) — and would fail even with proxy env vars set on the pod, because service docker start sanitizes the environment, so dockerd never sees them
4. launcher crash-loops

## Launcher

- the docker daemon config handling (previously only for insecure registries) now also renders a proxies section into /etc/docker/daemon.json from HTTP_PROXY/HTTPS_PROXY/NO_PROXY (upper/lowercase) found in the pod env — dockerd pulls work through the proxy no matter how it is started; a user-provided dockerDaemonConfig secret still takes precedence
- the template + manual JSON quoting is replaced with plain json.Marshal (drops launcher/assets embed entirely)
- on startup the launcher appends KUBERNETES_SERVICE_HOST to NO_PROXY/no_proxy before building clients, so proxy env vars passed via extraEnv can never accidentally route kube API traffic (and thus image pull through requests) into the proxy

Proxy env vars reach launchers through the existing extraEnv plumbing (Topology spec.deployment.extraEnv or global config), no new API surface.

## try-c9s

- make try-c9s now auto-detects proxy env vars on the host and passes them to launcher pods via globalConfig.deployment.extraEnv, with NO_PROXY extended by the KinD service/pod CIDRs and cluster-local suffixes; no-op when no proxy is set
- tool downloads retry transient failures (--retry 3 --retry-all-errors), since flaky corporate proxies like to break fresh TLS connections

## Docs

- new "HTTP(S) Proxy Support" section in docs/guides/image-pull.md, pointer comment on the chart's extraEnv value