### PR TITLE
Make Link crs the single source of truth for cross launcher links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,12 @@ run-client-gen: ## Run client-gen
 
 run-generate-crds: ## Run controller-gen for crds
 	controller-gen crd paths=./apis/... output:crd:dir=./charts/clabernetes/crds/
-
-# note: crds must be generated *before* openapi-gen -- the openapi json (and from it the ui
-# client types) is derived from the crd yamls, so the old order needed two passes to converge
-run-generate: install-code-generators run-deepcopy-gen run-generate-crds run-openapi-gen run-client-gen fmt ## Run all code gen tasks
 	cp charts/clabernetes/crds/*.yaml assets/crd/
+
+# note: crds must be generated (and synced into assets/crd/, which is what crds-to-openapi
+# reads) *before* openapi-gen -- the openapi json (and from it the ui client types) is derived
+# from the crd yamls, so any other order needs two passes to converge
+run-generate: install-code-generators run-deepcopy-gen run-generate-crds run-openapi-gen run-client-gen fmt ## Run all code gen tasks
 	npm --prefix ui ci
 	$(MAKE) --no-print-directory -C ui regenerate-types
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,9 @@ run-client-gen: ## Run client-gen
 run-generate-crds: ## Run controller-gen for crds
 	controller-gen crd paths=./apis/... output:crd:dir=./charts/clabernetes/crds/
 
-run-generate: install-code-generators run-deepcopy-gen run-openapi-gen run-client-gen run-generate-crds fmt ## Run all code gen tasks
+# note: crds must be generated *before* openapi-gen -- the openapi json (and from it the ui
+# client types) is derived from the crd yamls, so the old order needed two passes to converge
+run-generate: install-code-generators run-deepcopy-gen run-generate-crds run-openapi-gen run-client-gen fmt ## Run all code gen tasks
 	cp charts/clabernetes/crds/*.yaml assets/crd/
 	npm --prefix ui ci
 	$(MAKE) --no-print-directory -C ui regenerate-types

--- a/apis/v1alpha1/link.go
+++ b/apis/v1alpha1/link.go
@@ -12,7 +12,10 @@ import (
 // per inter-launcher link -- and hold everything both launcher pods need to establish the tunnel
 // (vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big
 // connectivity object) means no single object grows with the size of the topology, which keeps
-// clabernetes clear of the etcd max object size limits for very large topologies.
+// clabernetes clear of the etcd max object size limits for very large topologies. The
+// "clabernetes/linkEndpointA" and "clabernetes/linkEndpointB" labels hold the launcher nodes
+// that terminate each side (the primary node for grouped nodes) -- launchers select "their"
+// links by those labels and derive the remote fabric service from them.
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path="links",shortName="c9slink"
 // +kubebuilder:printcolumn:JSONPath=".spec.topologyName",name=Topology,type=string
@@ -35,13 +38,6 @@ type LinkEndpointSpec struct {
 	NodeName string `json:"nodeName"`
 	// InterfaceName is the name of the interface on the node this side of the link is on.
 	InterfaceName string `json:"interfaceName"`
-	// LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-	// of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-	// simply the same as NodeName.
-	LauncherNode string `json:"launcherNode"`
-	// Destination is the qualified kubernetes service name over which this side of the link can
-	// be reached (that is, the service the *other* side of the link connects to).
-	Destination string `json:"destination"`
 }
 
 // LinkSpec is the spec for a Link resource.
@@ -74,8 +70,10 @@ type LinkStatus struct{}
 type PointToPointTunnel struct {
 	// TunnelID is the id number of the tunnel (vnid or segment id).
 	TunnelID int `json:"tunnelID"`
-	// Destination is the destination service to connect to (qualified k8s service name).
-	Destination string `json:"destination"`
+	// Destination is the destination service to connect to (qualified k8s service name) --
+	// launchers derive this from the link's topology name and the remote launcher node (which
+	// they read from the link's endpoint labels).
+	Destination string `json:"destination,omitempty"`
 	// LocalNodeName is the name (in the clabernetes topology) of the local node for this side of
 	// the tunnel.
 	LocalNode string `json:"localNode"`

--- a/apis/v1alpha1/link.go
+++ b/apis/v1alpha1/link.go
@@ -57,6 +57,11 @@ type LinkSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=16000000
 	TunnelID int `json:"tunnelID"`
+	// MTU is the mtu for the link as set in the original topology definition -- launchers apply
+	// this to the (node side of the) link termination they create; zero means "unset" (use the
+	// containerlab default).
+	// +optional
+	MTU int `json:"mtu,omitempty"`
 }
 
 // LinkStatus is the status for a Link resource.
@@ -83,6 +88,9 @@ type PointToPointTunnel struct {
 	// can properly align tunnels (and ids!) between nodes; basically to know which tunnels are
 	// "paired up".
 	RemoteInterface string `json:"remoteInterface"`
+	// MTU is the mtu for the link this tunnel realizes; zero means "unset" (use the containerlab
+	// default).
+	MTU int `json:"mtu,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/apis/v1alpha1/link.go
+++ b/apis/v1alpha1/link.go
@@ -23,7 +23,7 @@ import (
 // +kubebuilder:printcolumn:JSONPath=".spec.endpointA.interfaceName",name=Interface-A,type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.endpointB.nodeName",name=Node-B,type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.endpointB.interfaceName",name=Interface-B,type=string
-// +kubebuilder:printcolumn:JSONPath=".spec.tunnelID",name=Tunnel-ID,type=integer
+// +kubebuilder:printcolumn:JSONPath=".status.tunnelID",name=Tunnel-ID,type=integer
 type Link struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,7 +40,9 @@ type LinkEndpointSpec struct {
 	InterfaceName string `json:"interfaceName"`
 }
 
-// LinkSpec is the spec for a Link resource.
+// LinkSpec is the spec for a Link resource. It holds only the "wire as the user drew it" --
+// anything operational (like the allocated tunnel id) lives in the status or is derived by the
+// launchers.
 type LinkSpec struct {
 	// TopologyName is the name of the Topology this Link belongs to.
 	TopologyName string `json:"topologyName"`
@@ -48,11 +50,6 @@ type LinkSpec struct {
 	EndpointA LinkEndpointSpec `json:"endpointA"`
 	// EndpointB is the "b" side of this link.
 	EndpointB LinkEndpointSpec `json:"endpointB"`
-	// TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of
-	// the link use the same id.
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=16000000
-	TunnelID int `json:"tunnelID"`
 	// MTU is the mtu for the link as set in the original topology definition -- launchers apply
 	// this to the (node side of the) link termination they create; zero means "unset" (use the
 	// containerlab default).
@@ -61,7 +58,16 @@ type LinkSpec struct {
 }
 
 // LinkStatus is the status for a Link resource.
-type LinkStatus struct{}
+type LinkStatus struct {
+	// TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for
+	// this link -- both sides of the link use the same id. This is an allocation rather than user
+	// intent, hence it living in the status; zero means "not allocated yet" (launchers skip such
+	// links until the controller has filled the id in).
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=16000000
+	// +optional
+	TunnelID int `json:"tunnelID,omitempty"`
+}
 
 // PointToPointTunnel holds the *local view* of a tunnel between two interfaces on different nodes
 // of a clabernetes Topology -- launchers derive this view from the Link objects relevant to their

--- a/assets/crd/clabernetes.containerlab.dev_links.yaml
+++ b/assets/crd/clabernetes.containerlab.dev_links.yaml
@@ -44,7 +44,10 @@ spec:
           per inter-launcher link -- and hold everything both launcher pods need to establish the tunnel
           (vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big
           connectivity object) means no single object grows with the size of the topology, which keeps
-          clabernetes clear of the etcd max object size limits for very large topologies.
+          clabernetes clear of the etcd max object size limits for very large topologies. The
+          "clabernetes/linkEndpointA" and "clabernetes/linkEndpointB" labels hold the launcher nodes
+          that terminate each side (the primary node for grouped nodes) -- launchers select "their"
+          links by those labels and derive the remote fabric service from them.
         properties:
           apiVersion:
             description: |-
@@ -69,57 +72,31 @@ spec:
               endpointA:
                 description: EndpointA is the "a" side of this link.
                 properties:
-                  destination:
-                    description: |-
-                      Destination is the qualified kubernetes service name over which this side of the link can
-                      be reached (that is, the service the *other* side of the link connects to).
-                    type: string
                   interfaceName:
                     description: InterfaceName is the name of the interface on the
                       node this side of the link is on.
-                    type: string
-                  launcherNode:
-                    description: |-
-                      LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-                      of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-                      simply the same as NodeName.
                     type: string
                   nodeName:
                     description: NodeName is the name of the (containerlab) node this
                       side of the link resides on.
                     type: string
                 required:
-                - destination
                 - interfaceName
-                - launcherNode
                 - nodeName
                 type: object
               endpointB:
                 description: EndpointB is the "b" side of this link.
                 properties:
-                  destination:
-                    description: |-
-                      Destination is the qualified kubernetes service name over which this side of the link can
-                      be reached (that is, the service the *other* side of the link connects to).
-                    type: string
                   interfaceName:
                     description: InterfaceName is the name of the interface on the
                       node this side of the link is on.
-                    type: string
-                  launcherNode:
-                    description: |-
-                      LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-                      of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-                      simply the same as NodeName.
                     type: string
                   nodeName:
                     description: NodeName is the name of the (containerlab) node this
                       side of the link resides on.
                     type: string
                 required:
-                - destination
                 - interfaceName
-                - launcherNode
                 - nodeName
                 type: object
               mtu:

--- a/assets/crd/clabernetes.containerlab.dev_links.yaml
+++ b/assets/crd/clabernetes.containerlab.dev_links.yaml
@@ -32,7 +32,7 @@ spec:
     - jsonPath: .spec.endpointB.interfaceName
       name: Interface-B
       type: string
-    - jsonPath: .spec.tunnelID
+    - jsonPath: .status.tunnelID
       name: Tunnel-ID
       type: integer
     name: v1alpha1
@@ -67,7 +67,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: LinkSpec is the spec for a Link resource.
+            description: |-
+              LinkSpec is the spec for a Link resource. It holds only the "wire as the user drew it" --
+              anything operational (like the allocated tunnel id) lives in the status or is derived by the
+              launchers.
             properties:
               endpointA:
                 description: EndpointA is the "a" side of this link.
@@ -109,21 +112,23 @@ spec:
                 description: TopologyName is the name of the Topology this Link belongs
                   to.
                 type: string
-              tunnelID:
-                description: |-
-                  TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of
-                  the link use the same id.
-                maximum: 16000000
-                minimum: 1
-                type: integer
             required:
             - endpointA
             - endpointB
             - topologyName
-            - tunnelID
             type: object
           status:
             description: LinkStatus is the status for a Link resource.
+            properties:
+              tunnelID:
+                description: |-
+                  TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for
+                  this link -- both sides of the link use the same id. This is an allocation rather than user
+                  intent, hence it living in the status; zero means "not allocated yet" (launchers skip such
+                  links until the controller has filled the id in).
+                maximum: 16000000
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true

--- a/assets/crd/clabernetes.containerlab.dev_links.yaml
+++ b/assets/crd/clabernetes.containerlab.dev_links.yaml
@@ -122,6 +122,12 @@ spec:
                 - launcherNode
                 - nodeName
                 type: object
+              mtu:
+                description: |-
+                  MTU is the mtu for the link as set in the original topology definition -- launchers apply
+                  this to the (node side of the) link termination they create; zero means "unset" (use the
+                  containerlab default).
+                type: integer
               topologyName:
                 description: TopologyName is the name of the Topology this Link belongs
                   to.

--- a/charts/clabernetes/crds/clabernetes.containerlab.dev_links.yaml
+++ b/charts/clabernetes/crds/clabernetes.containerlab.dev_links.yaml
@@ -44,7 +44,10 @@ spec:
           per inter-launcher link -- and hold everything both launcher pods need to establish the tunnel
           (vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big
           connectivity object) means no single object grows with the size of the topology, which keeps
-          clabernetes clear of the etcd max object size limits for very large topologies.
+          clabernetes clear of the etcd max object size limits for very large topologies. The
+          "clabernetes/linkEndpointA" and "clabernetes/linkEndpointB" labels hold the launcher nodes
+          that terminate each side (the primary node for grouped nodes) -- launchers select "their"
+          links by those labels and derive the remote fabric service from them.
         properties:
           apiVersion:
             description: |-
@@ -69,57 +72,31 @@ spec:
               endpointA:
                 description: EndpointA is the "a" side of this link.
                 properties:
-                  destination:
-                    description: |-
-                      Destination is the qualified kubernetes service name over which this side of the link can
-                      be reached (that is, the service the *other* side of the link connects to).
-                    type: string
                   interfaceName:
                     description: InterfaceName is the name of the interface on the
                       node this side of the link is on.
-                    type: string
-                  launcherNode:
-                    description: |-
-                      LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-                      of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-                      simply the same as NodeName.
                     type: string
                   nodeName:
                     description: NodeName is the name of the (containerlab) node this
                       side of the link resides on.
                     type: string
                 required:
-                - destination
                 - interfaceName
-                - launcherNode
                 - nodeName
                 type: object
               endpointB:
                 description: EndpointB is the "b" side of this link.
                 properties:
-                  destination:
-                    description: |-
-                      Destination is the qualified kubernetes service name over which this side of the link can
-                      be reached (that is, the service the *other* side of the link connects to).
-                    type: string
                   interfaceName:
                     description: InterfaceName is the name of the interface on the
                       node this side of the link is on.
-                    type: string
-                  launcherNode:
-                    description: |-
-                      LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-                      of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-                      simply the same as NodeName.
                     type: string
                   nodeName:
                     description: NodeName is the name of the (containerlab) node this
                       side of the link resides on.
                     type: string
                 required:
-                - destination
                 - interfaceName
-                - launcherNode
                 - nodeName
                 type: object
               mtu:

--- a/charts/clabernetes/crds/clabernetes.containerlab.dev_links.yaml
+++ b/charts/clabernetes/crds/clabernetes.containerlab.dev_links.yaml
@@ -32,7 +32,7 @@ spec:
     - jsonPath: .spec.endpointB.interfaceName
       name: Interface-B
       type: string
-    - jsonPath: .spec.tunnelID
+    - jsonPath: .status.tunnelID
       name: Tunnel-ID
       type: integer
     name: v1alpha1
@@ -67,7 +67,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: LinkSpec is the spec for a Link resource.
+            description: |-
+              LinkSpec is the spec for a Link resource. It holds only the "wire as the user drew it" --
+              anything operational (like the allocated tunnel id) lives in the status or is derived by the
+              launchers.
             properties:
               endpointA:
                 description: EndpointA is the "a" side of this link.
@@ -109,21 +112,23 @@ spec:
                 description: TopologyName is the name of the Topology this Link belongs
                   to.
                 type: string
-              tunnelID:
-                description: |-
-                  TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of
-                  the link use the same id.
-                maximum: 16000000
-                minimum: 1
-                type: integer
             required:
             - endpointA
             - endpointB
             - topologyName
-            - tunnelID
             type: object
           status:
             description: LinkStatus is the status for a Link resource.
+            properties:
+              tunnelID:
+                description: |-
+                  TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for
+                  this link -- both sides of the link use the same id. This is an allocation rather than user
+                  intent, hence it living in the status; zero means "not allocated yet" (launchers skip such
+                  links until the controller has filled the id in).
+                maximum: 16000000
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true

--- a/charts/clabernetes/crds/clabernetes.containerlab.dev_links.yaml
+++ b/charts/clabernetes/crds/clabernetes.containerlab.dev_links.yaml
@@ -122,6 +122,12 @@ spec:
                 - launcherNode
                 - nodeName
                 type: object
+              mtu:
+                description: |-
+                  MTU is the mtu for the link as set in the original topology definition -- launchers apply
+                  this to the (node side of the) link termination they create; zero means "unset" (use the
+                  containerlab default).
+                type: integer
               topologyName:
                 description: TopologyName is the name of the Topology this Link belongs
                   to.

--- a/constants/annotations.go
+++ b/constants/annotations.go
@@ -1,0 +1,11 @@
+package constants
+
+const (
+	// AnnotationLinkAttachmentsDigest is the annotation set on launcher deployment pod templates
+	// holding a digest of the node's local link attachment points (the interfaces the launcher
+	// creates host side veths for). Adding/removing a link (or changing its mtu) changes the
+	// digest, which rolls the pod so the launcher can redeploy the topology with the correct
+	// attachment set -- while remote-side-only link changes (rewires) leave the digest (and the
+	// pod) alone and are handled live by the launcher's link watch.
+	AnnotationLinkAttachmentsDigest = "clabernetes/linkAttachmentsDigest"
+)

--- a/constants/env.go
+++ b/constants/env.go
@@ -93,6 +93,16 @@ const (
 	// topology that a given launcher is responsible for.
 	LauncherNodeImageEnv = "LAUNCHER_NODE_IMAGE"
 
+	// LauncherTopologyRemovePrefixEnv is the env var that tells the launcher whether the topology
+	// resources are named without the topology name prefix -- the launcher needs this to derive
+	// the fabric service names of remote launchers from its link crs.
+	LauncherTopologyRemovePrefixEnv = "LAUNCHER_TOPOLOGY_REMOVE_PREFIX"
+
+	// LauncherInClusterDNSSuffixEnv is the env var that holds the in cluster dns suffix (from the
+	// global config) -- the launcher needs this to derive the fabric service names of remote
+	// launchers from its link crs.
+	LauncherInClusterDNSSuffixEnv = "LAUNCHER_IN_CLUSTER_DNS_SUFFIX"
+
 	// LauncherConnectivityKind is the env var that holds the flavor cf connectivity the launcher
 	// should run (vxlan/slurpeeth).
 	LauncherConnectivityKind = "LAUNCHER_CONNECTIVITY_KIND"

--- a/controllers/topology/definition.go
+++ b/controllers/topology/definition.go
@@ -63,15 +63,6 @@ type definitionProcessor struct {
 	configManagerGetter clabernetesconfig.ManagerGetterFunc
 }
 
-func (p *definitionProcessor) getRemoveTopologyPrefix() bool {
-	var removeTopologyPrefix bool
-	if ResolveTopologyRemovePrefix(p.topology) {
-		removeTopologyPrefix = true
-	}
-
-	return removeTopologyPrefix
-}
-
 func (c *Controller) processDefinition(
 	topology *clabernetesapisv1alpha1.Topology,
 	reconcileData *ReconcileData,

--- a/controllers/topology/definitioncontainerlab.go
+++ b/controllers/topology/definitioncontainerlab.go
@@ -88,9 +88,6 @@ func (p *containerlabDefinitionProcessor) Process() error {
 		return err
 	}
 
-	// check this here so we only have to check it once
-	removeTopologyPrefix := p.getRemoveTopologyPrefix()
-
 	// Build node groups for distributed systems (e.g., SR-SIM with network-mode: container:<name>)
 	nodeGroups, secondaryNodes := buildNodeGroups(containerlabConfig.Topology.Nodes)
 
@@ -107,9 +104,7 @@ func (p *containerlabDefinitionProcessor) Process() error {
 			containerlabConfig,
 			nodeName,
 			group,
-			secondaryNodes,
 			defaultsYAML,
-			removeTopologyPrefix,
 		)
 		if err != nil {
 			return err
@@ -543,15 +538,11 @@ func parseLinkEndpoints(link *clabernetesutilcontainerlab.LinkDefinition) (*link
 // For grouped nodes (distributed systems like SR-SIM), it creates a single sub-topology
 // containing all nodes in the group so they can be deployed in the same pod and share
 // the network namespace.
-// The secondaryNodes map is used to resolve tunnel destinations - if a remote node is a
-// secondary, the tunnel should point to its primary's service instead.
 func (p *containerlabDefinitionProcessor) processConfigForNodeGroup(
 	containerlabConfig *clabernetesutilcontainerlab.Config,
 	primaryNodeName string,
 	group *nodeGroup,
-	secondaryNodes map[string]string,
 	defaultsYAML []byte,
-	removeTopologyPrefix bool,
 ) error {
 	deepCopiedDefaults := &clabernetesutilcontainerlab.NodeDefinition{}
 
@@ -594,8 +585,6 @@ func (p *containerlabDefinitionProcessor) processConfigForNodeGroup(
 		containerlabConfig,
 		primaryNodeName,
 		groupNodesSet,
-		secondaryNodes,
-		removeTopologyPrefix,
 	)
 }
 
@@ -604,8 +593,6 @@ func (p *containerlabDefinitionProcessor) processLinksForNodeGroup(
 	containerlabConfig *clabernetesutilcontainerlab.Config,
 	primaryNodeName string,
 	groupNodesSet clabernetesutil.StringSet,
-	secondaryNodes map[string]string,
-	removeTopologyPrefix bool,
 ) error {
 	for _, link := range containerlabConfig.Topology.Links {
 		endpoints, err := parseLinkEndpoints(link)
@@ -620,8 +607,6 @@ func (p *containerlabDefinitionProcessor) processLinksForNodeGroup(
 			endpoints,
 			primaryNodeName,
 			groupNodesSet,
-			secondaryNodes,
-			removeTopologyPrefix,
 		)
 		if err != nil {
 			return err
@@ -637,8 +622,6 @@ func (p *containerlabDefinitionProcessor) processLinkForGroup(
 	endpoints *linkEndpoints,
 	primaryNodeName string,
 	groupNodesSet clabernetesutil.StringSet,
-	secondaryNodes map[string]string,
-	removeTopologyPrefix bool,
 ) error {
 	endpointAInGroup := groupNodesSet.Contains(endpoints.endpointA.NodeName)
 	endpointBInGroup := groupNodesSet.Contains(endpoints.endpointB.NodeName)
@@ -691,24 +674,13 @@ func (p *containerlabDefinitionProcessor) processLinkForGroup(
 
 	// cross launcher links only become tunnels (and from those, link crs) -- the "node <-> host"
 	// stanza that realizes the local half of such a link is launcher plumbing and is synthesized
-	// by the launcher itself from its link crs
-	destinationNodeName := uninterestingEndpoint.NodeName
-	if remotePrimary, isSecondary := secondaryNodes[uninterestingEndpoint.NodeName]; isSecondary {
-		destinationNodeName = remotePrimary
-	}
-
+	// by the launcher itself from its link crs, as is the destination service (derived from the
+	// topology name and the remote launcher node held in the link cr labels)
 	p.reconcileData.ResolvedTunnels[primaryNodeName] = append(
 		p.reconcileData.ResolvedTunnels[primaryNodeName],
 		&clabernetesapisv1alpha1.PointToPointTunnel{
-			LocalNode:  interestingEndpoint.NodeName,
-			RemoteNode: uninterestingEndpoint.NodeName,
-			Destination: resolveConnectivityDestination(
-				p.topology.Name,
-				destinationNodeName,
-				p.topology.Namespace,
-				removeTopologyPrefix,
-				p.configManagerGetter,
-			),
+			LocalNode:       interestingEndpoint.NodeName,
+			RemoteNode:      uninterestingEndpoint.NodeName,
 			LocalInterface:  interestingEndpoint.InterfaceName,
 			RemoteInterface: uninterestingEndpoint.InterfaceName,
 			MTU:             link.MTU,

--- a/controllers/topology/definitioncontainerlab.go
+++ b/controllers/topology/definitioncontainerlab.go
@@ -398,28 +398,6 @@ func getKindsForNode(
 	return nil
 }
 
-func getDestinationLinkEndpoint(
-	targetNode string,
-	interestingEndpoint clabernetesapisv1alpha1.LinkEndpoint,
-	uninterestingEndpoint clabernetesapisv1alpha1.LinkEndpoint,
-) string {
-	if targetNode == clabernetesconstants.HostKeyword {
-		// It is a containerlab host entry, so the original provided interface is preserved
-		return fmt.Sprintf(
-			"%s:%s",
-			clabernetesconstants.HostKeyword,
-			uninterestingEndpoint.InterfaceName,
-		)
-	}
-
-	return fmt.Sprintf(
-		"%s:%s-%s",
-		clabernetesconstants.HostKeyword,
-		interestingEndpoint.NodeName,
-		interestingEndpoint.InterfaceName,
-	)
-}
-
 // nodeGroupContext holds the context needed for processing a node group.
 type nodeGroupContext struct {
 	containerlabConfig *clabernetesutilcontainerlab.Config
@@ -683,29 +661,37 @@ func (p *containerlabDefinitionProcessor) processLinkForGroup(
 		interestingEndpoint, uninterestingEndpoint = endpoints.endpointB, endpoints.endpointA
 	}
 
-	p.reconcileData.ResolvedConfigs[primaryNodeName].Topology.Links = append(
-		p.reconcileData.ResolvedConfigs[primaryNodeName].Topology.Links,
-		&clabernetesutilcontainerlab.LinkDefinition{
-			LinkConfig: clabernetesutilcontainerlab.LinkConfig{
-				Endpoints: []string{
-					fmt.Sprintf("%s:%s",
-						interestingEndpoint.NodeName,
-						interestingEndpoint.InterfaceName,
-					),
-					getDestinationLinkEndpoint(
-						uninterestingEndpoint.NodeName,
-						interestingEndpoint,
-						uninterestingEndpoint,
-					),
+	if uninterestingEndpoint.NodeName == clabernetesconstants.HostKeyword {
+		// genuine (user defined) host links are node local -- they stay in the sub-topology,
+		// keeping the original host interface name and link attributes
+		p.reconcileData.ResolvedConfigs[primaryNodeName].Topology.Links = append(
+			p.reconcileData.ResolvedConfigs[primaryNodeName].Topology.Links,
+			&clabernetesutilcontainerlab.LinkDefinition{
+				Type: link.Type,
+				LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+					Endpoints: []string{
+						fmt.Sprintf("%s:%s",
+							interestingEndpoint.NodeName,
+							interestingEndpoint.InterfaceName,
+						),
+						fmt.Sprintf("%s:%s",
+							clabernetesconstants.HostKeyword,
+							uninterestingEndpoint.InterfaceName,
+						),
+					},
+					MTU:    link.MTU,
+					Labels: link.Labels,
+					Vars:   link.Vars,
 				},
 			},
-		},
-	)
+		)
 
-	if uninterestingEndpoint.NodeName == clabernetesconstants.HostKeyword {
 		return nil
 	}
 
+	// cross launcher links only become tunnels (and from those, link crs) -- the "node <-> host"
+	// stanza that realizes the local half of such a link is launcher plumbing and is synthesized
+	// by the launcher itself from its link crs
 	destinationNodeName := uninterestingEndpoint.NodeName
 	if remotePrimary, isSecondary := secondaryNodes[uninterestingEndpoint.NodeName]; isSecondary {
 		destinationNodeName = remotePrimary
@@ -725,6 +711,7 @@ func (p *containerlabDefinitionProcessor) processLinkForGroup(
 			),
 			LocalInterface:  interestingEndpoint.InterfaceName,
 			RemoteInterface: uninterestingEndpoint.InterfaceName,
+			MTU:             link.MTU,
 		},
 	)
 

--- a/controllers/topology/definitionkne.go
+++ b/controllers/topology/definitionkne.go
@@ -24,18 +24,13 @@ func (p *kneDefinitionProcessor) Process() error {
 		return err
 	}
 
-	// check this here so we only have to check it once
-	removeTopologyPrefix := p.getRemoveTopologyPrefix()
-
-	return p.processKneDefinition(kneTopo, removeTopologyPrefix)
+	return p.processKneDefinition(kneTopo)
 }
 
 func (p *kneDefinitionProcessor) processConfigNodeLinks(
-	topology *clabernetesapisv1alpha1.Topology,
 	nodeName string,
 	link *knetopologyproto.Link,
 	reconcileData *ReconcileData,
-	removeTopologyPrefix bool,
 ) {
 	endpointA := clabernetesapisv1alpha1.LinkEndpoint{
 		NodeName:      link.ANode,
@@ -79,19 +74,13 @@ func (p *kneDefinitionProcessor) processConfigNodeLinks(
 
 	// cross launcher links only become tunnels (and from those, link crs) -- the "node <-> host"
 	// stanza that realizes the local half of such a link is launcher plumbing and is synthesized
-	// by the launcher itself from its link crs
+	// by the launcher itself from its link crs, as is the destination service (derived from the
+	// topology name and the remote launcher node held in the link cr labels)
 	reconcileData.ResolvedTunnels[nodeName] = append(
 		reconcileData.ResolvedTunnels[nodeName],
 		&clabernetesapisv1alpha1.PointToPointTunnel{
-			LocalNode:  nodeName,
-			RemoteNode: uninterestingEndpoint.NodeName,
-			Destination: resolveConnectivityDestination(
-				topology.Name,
-				uninterestingEndpoint.NodeName,
-				topology.Namespace,
-				removeTopologyPrefix,
-				p.configManagerGetter,
-			),
+			LocalNode:       nodeName,
+			RemoteNode:      uninterestingEndpoint.NodeName,
 			LocalInterface:  interestingEndpoint.InterfaceName,
 			RemoteInterface: uninterestingEndpoint.InterfaceName,
 		},
@@ -100,7 +89,6 @@ func (p *kneDefinitionProcessor) processConfigNodeLinks(
 
 func (p *kneDefinitionProcessor) processKneDefinition(
 	kneTopo *knetopologyproto.Topology,
-	removeTopologyPrefix bool,
 ) error {
 	// making many assumptions that things that are pointers are not going to be nil... since
 	// basically everything in the kne topology obj is pointers
@@ -169,11 +157,9 @@ func (p *kneDefinitionProcessor) processKneDefinition(
 
 		for _, link := range kneTopo.Links {
 			p.processConfigNodeLinks(
-				p.topology,
 				nodeName,
 				link,
 				p.reconcileData,
-				removeTopologyPrefix,
 			)
 		}
 	}

--- a/controllers/topology/definitionkne.go
+++ b/controllers/topology/definitionkne.go
@@ -77,26 +77,9 @@ func (p *kneDefinitionProcessor) processConfigNodeLinks(
 		uninterestingEndpoint = endpointA
 	}
 
-	reconcileData.ResolvedConfigs[nodeName].Topology.Links = append(
-		reconcileData.ResolvedConfigs[nodeName].Topology.Links,
-		&clabernetesutilcontainerlab.LinkDefinition{
-			LinkConfig: clabernetesutilcontainerlab.LinkConfig{
-				Endpoints: []string{
-					fmt.Sprintf(
-						"%s:%s",
-						interestingEndpoint.NodeName,
-						interestingEndpoint.InterfaceName,
-					),
-					fmt.Sprintf(
-						"host:%s-%s",
-						interestingEndpoint.NodeName,
-						interestingEndpoint.InterfaceName,
-					),
-				},
-			},
-		},
-	)
-
+	// cross launcher links only become tunnels (and from those, link crs) -- the "node <-> host"
+	// stanza that realizes the local half of such a link is launcher plumbing and is synthesized
+	// by the launcher itself from its link crs
 	reconcileData.ResolvedTunnels[nodeName] = append(
 		reconcileData.ResolvedTunnels[nodeName],
 		&clabernetesapisv1alpha1.PointToPointTunnel{

--- a/controllers/topology/deployment.go
+++ b/controllers/topology/deployment.go
@@ -783,6 +783,14 @@ func (r *DeploymentReconciler) renderDeploymentContainerEnv( //nolint: funlen
 			Value: owningTopology.Spec.Connectivity,
 		},
 		{
+			Name:  clabernetesconstants.LauncherTopologyRemovePrefixEnv,
+			Value: strconv.FormatBool(ResolveTopologyRemovePrefix(owningTopology)),
+		},
+		{
+			Name:  clabernetesconstants.LauncherInClusterDNSSuffixEnv,
+			Value: r.configManagerGetter().GetInClusterDNSSuffix(),
+		},
+		{
 			Name:  clabernetesconstants.LauncherContainerlabVersion,
 			Value: containerlabVersion,
 		},

--- a/controllers/topology/deployment.go
+++ b/controllers/topology/deployment.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -58,6 +59,28 @@ func NewDeploymentReconciler(
 	}
 }
 
+// linkAttachmentsDigest returns a digest of the local link attachment points of the given (per
+// launcher node) tunnels -- the local node/interface (plus mtu) pairs the launcher creates host
+// side veths for. The digest is stamped on the launcher pod template so attachment set changes
+// roll the pod, while remote-side-only changes (which the launcher handles live via its link
+// watch) do not.
+func linkAttachmentsDigest(tunnels []*clabernetesapisv1alpha1.PointToPointTunnel) string {
+	attachments := make([]string, len(tunnels))
+
+	for idx, tunnel := range tunnels {
+		attachments[idx] = fmt.Sprintf(
+			"%s:%s:%d",
+			tunnel.LocalNode,
+			tunnel.LocalInterface,
+			tunnel.MTU,
+		)
+	}
+
+	slices.Sort(attachments)
+
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(attachments, ","))))
+}
+
 // Resolve accepts a mapping of clabernetes configs and a list of deployments that are -- by owner
 // reference and/or labels -- associated with the topology. It returns a ObjectDiffer object
 // that contains the missing, extra, and current deployments for the topology.
@@ -75,14 +98,16 @@ func (r *DeploymentReconciler) Resolve(
 	return ResolveOwnedObjectsByNodeLabel(ownedObjects, clabernetesConfigs)
 }
 
-// Render accepts the owning topology a mapping of clabernetes sub-topology configs and a node name
-// and renders the final deployment for this node.
+// Render accepts the owning topology, the reconcile data, and a node name and renders the final
+// deployment for this node.
 func (r *DeploymentReconciler) Render(
 	owningTopology *clabernetesapisv1alpha1.Topology,
-	clabernetesConfigs map[string]*clabernetesutilcontainerlab.Config,
+	reconcileData *ReconcileData,
 	nodeName string,
 ) *k8sappsv1.Deployment {
 	owningTopologyName := owningTopology.GetName()
+
+	clabernetesConfigs := reconcileData.ResolvedConfigs
 
 	deploymentName := NodeResourceName(owningTopology, nodeName)
 
@@ -92,6 +117,11 @@ func (r *DeploymentReconciler) Render(
 		owningTopologyName,
 		nodeName,
 	)
+
+	deployment.Spec.Template.ObjectMeta.Annotations[clabernetesconstants.AnnotationLinkAttachmentsDigest] = //nolint:lll
+		linkAttachmentsDigest(
+			reconcileData.ResolvedTunnels[nodeName],
+		)
 
 	r.renderDeploymentScheduling(
 		deployment,
@@ -160,11 +190,11 @@ func (r *DeploymentReconciler) Render(
 	return deployment
 }
 
-// RenderAll accepts the owning topology a mapping of clabernetes sub-topology configs and a
-// list of node names and renders the final deployments for the given nodes.
+// RenderAll accepts the owning topology, the reconcile data, and a list of node names and renders
+// the final deployments for the given nodes.
 func (r *DeploymentReconciler) RenderAll(
 	owningTopology *clabernetesapisv1alpha1.Topology,
-	clabernetesConfigs map[string]*clabernetesutilcontainerlab.Config,
+	reconcileData *ReconcileData,
 	nodeNames []string,
 ) []*k8sappsv1.Deployment {
 	deployments := make([]*k8sappsv1.Deployment, len(nodeNames))
@@ -172,7 +202,7 @@ func (r *DeploymentReconciler) RenderAll(
 	for idx, nodeName := range nodeNames {
 		deployments[idx] = r.Render(
 			owningTopology,
-			clabernetesConfigs,
+			reconcileData,
 			nodeName,
 		)
 	}
@@ -1221,26 +1251,11 @@ func determineNodeNeedsRestart(
 		return
 	}
 
-	if len(previousConfig.Topology.Links) != len(currentConfig.Topology.Links) {
-		// dont bother checking links since they cant be same/same, node needs rebooted to restart
-		// clab bits
-		reconcileData.NodesNeedingReboot.Add(nodeName)
-
-		return
-	}
-
-	// we know (because we set this) that topology will never be nil and links will always be slices
-	// that are len 2... so we are a little risky here but its probably ok :)
-	for idx := range previousConfig.Topology.Links {
-		previousASide := previousConfig.Topology.Links[idx].Endpoints[0]
-		currentASide := currentConfig.Topology.Links[idx].Endpoints[0]
-
-		if previousASide == currentASide {
-			// as long as "a" side is the same, things will auto update itself since launcher is
-			// watching the connectivity cr
-			continue
-		}
-
+	if !reflect.DeepEqual(previousConfig.Topology.Links, currentConfig.Topology.Links) {
+		// the links remaining in the sub-topology are all node local (user defined host links and
+		// links between grouped nodes) -- nothing watches/repairs those at runtime, so any change
+		// means the node needs a reboot to redeploy the clab bits. cross launcher links live on
+		// link crs and are handled via the link attachments digest on the deployment instead.
 		reconcileData.NodesNeedingReboot.Add(nodeName)
 
 		return

--- a/controllers/topology/deployment_test.go
+++ b/controllers/topology/deployment_test.go
@@ -134,6 +134,7 @@ func TestRenderDeployment(t *testing.T) {
 		criKind              string
 		imagePullThroughMode string
 		clabernetesConfigs   map[string]*clabernetesutilcontainerlab.Config
+		resolvedTunnels      map[string][]*clabernetesapisv1alpha1.PointToPointTunnel
 		nodeName             string
 		configManagerGetter  clabernetesconfig.ManagerGetterFunc
 	}{
@@ -191,6 +192,66 @@ func TestRenderDeployment(t *testing.T) {
 						Links: nil,
 					},
 					Debug: false,
+				},
+			},
+			nodeName:            "srl1",
+			configManagerGetter: clabernetesconfig.GetFakeManager,
+		},
+		{
+			name: "with-link-attachments",
+			owningTopology: &clabernetesapisv1alpha1.Topology{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "render-deployment-test",
+					Namespace: "clabernetes",
+				},
+				Spec: clabernetesapisv1alpha1.TopologySpec{
+					Connectivity: clabernetesconstants.ConnectivityVXLAN,
+					Definition: clabernetesapisv1alpha1.Definition{
+						Containerlab: `---
+    name: test
+    topology:
+      nodes:
+        srl1:
+          kind: srl
+          image: ghcr.io/nokia/srlinux
+        srl2:
+          kind: srl
+          image: ghcr.io/nokia/srlinux
+      links:
+        - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+`,
+					},
+				},
+			},
+			clabernetesConfigs: map[string]*clabernetesutilcontainerlab.Config{
+				"srl1": {
+					Name:   "srl1",
+					Prefix: clabernetesutil.ToPointer(""),
+					Topology: &clabernetesutilcontainerlab.Topology{
+						Defaults: &clabernetesutilcontainerlab.NodeDefinition{
+							Ports: []string{},
+						},
+						Kinds: nil,
+						Nodes: map[string]*clabernetesutilcontainerlab.NodeDefinition{
+							"srl1": {
+								Kind:  "srl",
+								Image: "ghcr.io/nokia/srlinux",
+							},
+						},
+						Links: nil,
+					},
+					Debug: false,
+				},
+			},
+			resolvedTunnels: map[string][]*clabernetesapisv1alpha1.PointToPointTunnel{
+				"srl1": {
+					{
+						LocalNode:       "srl1",
+						LocalInterface:  "e1-1",
+						RemoteNode:      "srl2",
+						RemoteInterface: "e1-1",
+						Destination:     "render-deployment-test-srl2-vx.clabernetes.svc.cluster.local",
+					},
 				},
 			},
 			nodeName:            "srl1",
@@ -793,7 +854,10 @@ func TestRenderDeployment(t *testing.T) {
 
 				got := reconciler.Render(
 					testCase.owningTopology,
-					testCase.clabernetesConfigs,
+					&clabernetescontrollerstopology.ReconcileData{
+						ResolvedConfigs: testCase.clabernetesConfigs,
+						ResolvedTunnels: testCase.resolvedTunnels,
+					},
 					testCase.nodeName,
 				)
 

--- a/controllers/topology/linkcr.go
+++ b/controllers/topology/linkcr.go
@@ -299,31 +299,27 @@ func (r *LinkReconciler) renderLink(
 ) *clabernetesapisv1alpha1.Link {
 	owningTopologyName := owningTopology.GetName()
 
-	// each halfs tunnel destination is the service of the *remote* side, so the "local" service
-	// for an endpoint (the service the other side dials) comes from the mirrored half
 	endpointA := clabernetesapisv1alpha1.LinkEndpointSpec{
 		NodeName:      halfA.tunnel.LocalNode,
 		InterfaceName: halfA.tunnel.LocalInterface,
-		LauncherNode:  halfA.launcherNode,
-		Destination:   halfB.tunnel.Destination,
 	}
 
 	endpointB := clabernetesapisv1alpha1.LinkEndpointSpec{
 		NodeName:      halfB.tunnel.LocalNode,
 		InterfaceName: halfB.tunnel.LocalInterface,
-		LauncherNode:  halfB.launcherNode,
-		Destination:   halfA.tunnel.Destination,
 	}
 
 	annotations, globalLabels := r.configManagerGetter().GetAllMetadata()
 
+	// the endpoint labels hold the launcher node terminating each side -- launchers watch their
+	// links via these labels and derive the remote fabric service name from them
 	labels := map[string]string{
 		clabernetesconstants.LabelApp:           clabernetesconstants.Clabernetes,
 		clabernetesconstants.LabelName:          owningTopologyName,
 		clabernetesconstants.LabelTopologyOwner: owningTopologyName,
 		clabernetesconstants.LabelTopologyKind:  GetTopologyKind(owningTopology),
-		clabernetesconstants.LabelLinkEndpointA: endpointA.LauncherNode,
-		clabernetesconstants.LabelLinkEndpointB: endpointB.LauncherNode,
+		clabernetesconstants.LabelLinkEndpointA: halfA.launcherNode,
+		clabernetesconstants.LabelLinkEndpointB: halfB.launcherNode,
 	}
 
 	maps.Copy(labels, globalLabels)

--- a/controllers/topology/linkcr.go
+++ b/controllers/topology/linkcr.go
@@ -339,6 +339,7 @@ func (r *LinkReconciler) renderLink(
 			TopologyName: owningTopologyName,
 			EndpointA:    endpointA,
 			EndpointB:    endpointB,
+			MTU:          halfA.tunnel.MTU,
 		},
 	}
 }

--- a/controllers/topology/linkcr.go
+++ b/controllers/topology/linkcr.go
@@ -170,8 +170,9 @@ func (r *LinkReconciler) RenderAll(
 	return links
 }
 
-// AllocateTunnelIDs assigns valid, unique tunnel ids to the rendered links. Existing valid ids are
-// retained in deterministic link-name order; duplicates and invalid values are reallocated.
+// AllocateTunnelIDs assigns valid, unique tunnel ids to the rendered links. Existing valid ids
+// (held in the link statuses, as tunnel ids are controller allocations rather than user intent)
+// are retained in deterministic link-name order; duplicates and invalid values are reallocated.
 func AllocateTunnelIDs(
 	existingLinks map[string]*clabernetesapisv1alpha1.Link,
 	renderedLinks []*clabernetesapisv1alpha1.Link,
@@ -190,20 +191,20 @@ func AllocateTunnelIDs(
 	for _, link := range renderedLinks {
 		existingLink, ok := existingLinks[link.Name]
 		if !ok ||
-			existingLink.Spec.TunnelID < 1 ||
-			existingLink.Spec.TunnelID > maxID ||
-			allocatedIDs[existingLink.Spec.TunnelID] {
+			existingLink.Status.TunnelID < 1 ||
+			existingLink.Status.TunnelID > maxID ||
+			allocatedIDs[existingLink.Status.TunnelID] {
 			continue
 		}
 
-		link.Spec.TunnelID = existingLink.Spec.TunnelID
-		allocatedIDs[link.Spec.TunnelID] = true
+		link.Status.TunnelID = existingLink.Status.TunnelID
+		allocatedIDs[link.Status.TunnelID] = true
 	}
 
 	nextID := 1
 
 	for _, link := range renderedLinks {
-		if link.Spec.TunnelID != 0 {
+		if link.Status.TunnelID != 0 {
 			continue
 		}
 
@@ -221,7 +222,7 @@ func AllocateTunnelIDs(
 			)
 		}
 
-		link.Spec.TunnelID = nextID
+		link.Status.TunnelID = nextID
 		allocatedIDs[nextID] = true
 	}
 
@@ -262,6 +263,12 @@ func (r *LinkReconciler) Conforms(
 	expectedOwnerUID apimachinerytypes.UID,
 ) bool {
 	if !reflect.DeepEqual(existingLink.Spec, renderedLink.Spec) {
+		return false
+	}
+
+	if existingLink.Status.TunnelID != renderedLink.Status.TunnelID {
+		// the allocated tunnel id lives in the status -- a wiped/drifted id needs to be written
+		// back (the allocator retains valid existing ids, so this only fires on actual drift)
 		return false
 	}
 

--- a/controllers/topology/linkcr_test.go
+++ b/controllers/topology/linkcr_test.go
@@ -150,7 +150,7 @@ func TestAllocateTunnelIDs(t *testing.T) {
 			existingLinks: map[string]*clabernetesapisv1alpha1.Link{
 				"link-b": {
 					ObjectMeta: metav1.ObjectMeta{Name: "link-b"},
-					Spec:       clabernetesapisv1alpha1.LinkSpec{TunnelID: 1},
+					Status:     clabernetesapisv1alpha1.LinkStatus{TunnelID: 1},
 				},
 			},
 			renderedLinks: []*clabernetesapisv1alpha1.Link{
@@ -166,7 +166,7 @@ func TestAllocateTunnelIDs(t *testing.T) {
 			existingLinks: map[string]*clabernetesapisv1alpha1.Link{
 				"link-gone": {
 					ObjectMeta: metav1.ObjectMeta{Name: "link-gone"},
-					Spec:       clabernetesapisv1alpha1.LinkSpec{TunnelID: 1},
+					Status:     clabernetesapisv1alpha1.LinkStatus{TunnelID: 1},
 				},
 			},
 			renderedLinks: []*clabernetesapisv1alpha1.Link{
@@ -180,11 +180,11 @@ func TestAllocateTunnelIDs(t *testing.T) {
 			existingLinks: map[string]*clabernetesapisv1alpha1.Link{
 				"link-a": {
 					ObjectMeta: metav1.ObjectMeta{Name: "link-a"},
-					Spec:       clabernetesapisv1alpha1.LinkSpec{TunnelID: 7},
+					Status:     clabernetesapisv1alpha1.LinkStatus{TunnelID: 7},
 				},
 				"link-b": {
 					ObjectMeta: metav1.ObjectMeta{Name: "link-b"},
-					Spec:       clabernetesapisv1alpha1.LinkSpec{TunnelID: 7},
+					Status:     clabernetesapisv1alpha1.LinkStatus{TunnelID: 7},
 				},
 			},
 			renderedLinks: []*clabernetesapisv1alpha1.Link{
@@ -199,11 +199,11 @@ func TestAllocateTunnelIDs(t *testing.T) {
 			existingLinks: map[string]*clabernetesapisv1alpha1.Link{
 				"link-a": {
 					ObjectMeta: metav1.ObjectMeta{Name: "link-a"},
-					Spec:       clabernetesapisv1alpha1.LinkSpec{TunnelID: -1},
+					Status:     clabernetesapisv1alpha1.LinkStatus{TunnelID: -1},
 				},
 				"link-b": {
 					ObjectMeta: metav1.ObjectMeta{Name: "link-b"},
-					Spec:       clabernetesapisv1alpha1.LinkSpec{TunnelID: 11},
+					Status:     clabernetesapisv1alpha1.LinkStatus{TunnelID: 11},
 				},
 			},
 			renderedLinks: []*clabernetesapisv1alpha1.Link{
@@ -248,10 +248,10 @@ func TestAllocateTunnelIDs(t *testing.T) {
 				}
 
 				for idx, renderedLink := range testCase.renderedLinks {
-					if renderedLink.Spec.TunnelID != testCase.expectedIDs[idx] {
+					if renderedLink.Status.TunnelID != testCase.expectedIDs[idx] {
 						clabernetestesthelper.FailOutput(
 							t,
-							renderedLink.Spec.TunnelID,
+							renderedLink.Status.TunnelID,
 							testCase.expectedIDs[idx],
 						)
 					}

--- a/controllers/topology/reconciler.go
+++ b/controllers/topology/reconciler.go
@@ -789,7 +789,7 @@ func (r *Reconciler) ReconcileDeployments( //nolint: gocyclo,funlen
 
 	renderedMissingDeployments := r.DeploymentReconciler.RenderAll(
 		owningTopology,
-		reconcileData.ResolvedConfigs,
+		reconcileData,
 		deployments.Missing,
 	)
 
@@ -810,7 +810,7 @@ func (r *Reconciler) ReconcileDeployments( //nolint: gocyclo,funlen
 	for existingCurrentDeploymentNodeName, existingCurrentDeployment := range deployments.Current {
 		renderedCurrentDeployment := r.DeploymentReconciler.Render(
 			owningTopology,
-			reconcileData.ResolvedConfigs,
+			reconcileData,
 			existingCurrentDeploymentNodeName,
 		)
 

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
@@ -249,7 +249,6 @@
         "srl1": [
             {
                 "tunnelID": 0,
-                "destination": "process-containerlab-definition-host-and-links-test-srl2-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl1",
                 "localInterface": "e1-1",
                 "remoteNode": "srl2",
@@ -259,7 +258,6 @@
         "srl2": [
             {
                 "tunnelID": 0,
-                "destination": "process-containerlab-definition-host-and-links-test-srl1-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl2",
                 "localInterface": "e1-1",
                 "remoteNode": "srl1",

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-host-and-links.json
@@ -112,16 +112,6 @@
                 "Links": [
                     {
                         "Endpoints": [
-                            "srl1:e1-1",
-                            "host:srl1-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    },
-                    {
-                        "Endpoints": [
                             "srl1:e3-3",
                             "host:eth3-3"
                         ],
@@ -250,18 +240,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl2:e1-1",
-                            "host:srl2-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         }

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-network-mode-group.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-network-mode-group.json
@@ -109,18 +109,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "external-node:e1-1",
-                            "host:external-node-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         },
@@ -364,18 +353,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srsim-iom1:1/1/c1/1",
-                            "host:srsim-iom1-1/1/c1/1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         }

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-network-mode-group.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-network-mode-group.json
@@ -362,7 +362,6 @@
         "external-node": [
             {
                 "tunnelID": 0,
-                "destination": "process-containerlab-definition-network-mode-test-srsim-a-vx.clabernetes.svc.cluster.local",
                 "localNode": "external-node",
                 "localInterface": "e1-1",
                 "remoteNode": "srsim-iom1",
@@ -372,7 +371,6 @@
         "srsim-a": [
             {
                 "tunnelID": 0,
-                "destination": "process-containerlab-definition-network-mode-test-external-node-vx.clabernetes.svc.cluster.local",
                 "localNode": "srsim-iom1",
                 "localInterface": "1/1/c1/1",
                 "remoteNode": "external-node",

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-simple-remove-prefix.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-simple-remove-prefix.json
@@ -109,18 +109,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl1:e1-1",
-                            "host:srl1-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         },
@@ -231,18 +220,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl2:e1-1",
-                            "host:srl2-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         }

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-simple-remove-prefix.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-simple-remove-prefix.json
@@ -229,7 +229,6 @@
         "srl1": [
             {
                 "tunnelID": 0,
-                "destination": "srl2-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl1",
                 "localInterface": "e1-1",
                 "remoteNode": "srl2",
@@ -239,7 +238,6 @@
         "srl2": [
             {
                 "tunnelID": 0,
-                "destination": "srl1-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl2",
                 "localInterface": "e1-1",
                 "remoteNode": "srl1",

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-simple.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-simple.json
@@ -109,18 +109,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl1:e1-1",
-                            "host:srl1-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         },
@@ -231,18 +220,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl2:e1-1",
-                            "host:srl2-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         }

--- a/controllers/topology/test-fixtures/golden/definition/containerlab-simple.json
+++ b/controllers/topology/test-fixtures/golden/definition/containerlab-simple.json
@@ -229,7 +229,6 @@
         "srl1": [
             {
                 "tunnelID": 0,
-                "destination": "process-containerlab-definition-test-srl2-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl1",
                 "localInterface": "e1-1",
                 "remoteNode": "srl2",
@@ -239,7 +238,6 @@
         "srl2": [
             {
                 "tunnelID": 0,
-                "destination": "process-containerlab-definition-test-srl1-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl2",
                 "localInterface": "e1-1",
                 "remoteNode": "srl1",

--- a/controllers/topology/test-fixtures/golden/definition/kne-simple-remove-prefix.json
+++ b/controllers/topology/test-fixtures/golden/definition/kne-simple-remove-prefix.json
@@ -211,7 +211,6 @@
         "srl1": [
             {
                 "tunnelID": 0,
-                "destination": "srl2-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl1",
                 "localInterface": "e1-1",
                 "remoteNode": "srl2",
@@ -221,7 +220,6 @@
         "srl2": [
             {
                 "tunnelID": 0,
-                "destination": "srl1-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl2",
                 "localInterface": "e1-1",
                 "remoteNode": "srl1",

--- a/controllers/topology/test-fixtures/golden/definition/kne-simple-remove-prefix.json
+++ b/controllers/topology/test-fixtures/golden/definition/kne-simple-remove-prefix.json
@@ -100,18 +100,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl1:e1-1",
-                            "host:srl1-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         },
@@ -213,18 +202,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl2:e1-1",
-                            "host:srl2-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         }

--- a/controllers/topology/test-fixtures/golden/definition/kne-simple.json
+++ b/controllers/topology/test-fixtures/golden/definition/kne-simple.json
@@ -100,18 +100,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl1:e1-1",
-                            "host:srl1-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         },
@@ -213,18 +202,7 @@
                         "Components": null
                     }
                 },
-                "Links": [
-                    {
-                        "Endpoints": [
-                            "srl2:e1-1",
-                            "host:srl2-e1-1"
-                        ],
-                        "Labels": null,
-                        "Vars": null,
-                        "MTU": 0,
-                        "Type": ""
-                    }
-                ]
+                "Links": null
             },
             "Debug": false
         }

--- a/controllers/topology/test-fixtures/golden/definition/kne-simple.json
+++ b/controllers/topology/test-fixtures/golden/definition/kne-simple.json
@@ -211,7 +211,6 @@
         "srl1": [
             {
                 "tunnelID": 0,
-                "destination": "process-kne-definition-test-srl2-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl1",
                 "localInterface": "e1-1",
                 "remoteNode": "srl2",
@@ -221,7 +220,6 @@
         "srl2": [
             {
                 "tunnelID": 0,
-                "destination": "process-kne-definition-test-srl1-vx.clabernetes.svc.cluster.local",
                 "localNode": "srl2",
                 "localInterface": "e1-1",
                 "remoteNode": "srl1",

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/containerlab-debug.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/containerlab-debug.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/containerlab-debug.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/containerlab-debug.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/custom-clab-version.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/custom-clab-version.json
@@ -128,6 +128,14 @@
                                 "name": "LAUNCHER_CONNECTIVITY_KIND"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "true"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION",
                                 "value": "0.51.1"
                             },

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/custom-clab-version.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/custom-clab-version.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-config.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-config.json
@@ -136,6 +136,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-config.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-config.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-daemon.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-daemon.json
@@ -136,6 +136,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-daemon.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/docker-daemon.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/insecure-registries.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/insecure-registries.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/insecure-registries.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/insecure-registries.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/launcher-log-level.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/launcher-log-level.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/launcher-log-level.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/launcher-log-level.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/not-privileged-launcher.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/not-privileged-launcher.json
@@ -152,6 +152,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/not-privileged-launcher.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/not-privileged-launcher.json
@@ -10,6 +10,7 @@
             "clabernetes/topologyOwner": "render-deployment-test"
         },
         "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "container.apparmor.security.beta.kubernetes.io/srl1": "unconfined"
         }
     },
@@ -34,6 +35,7 @@
                     "clabernetes/topologyOwner": "render-deployment-test"
                 },
                 "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                     "container.apparmor.security.beta.kubernetes.io/srl1": "unconfined"
                 }
             },

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/remove-prefix.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/remove-prefix.json
@@ -129,6 +129,14 @@
                                 "value": "slurpeeth"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "true"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/remove-prefix.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/remove-prefix.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/scheduling.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/scheduling.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/scheduling.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/scheduling.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/simple-node-selectors.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/simple-node-selectors.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/simple-node-selectors.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/simple-node-selectors.json
@@ -8,6 +8,9 @@
             "clabernetes/name": "render-deployment-test-node-selectors-srl1",
             "clabernetes/topologyNode": "srl1",
             "clabernetes/topologyOwner": "render-deployment-test-node-selectors"
+        },
+        "annotations": {
+            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "spec": {
@@ -29,6 +32,9 @@
                     "clabernetes/name": "render-deployment-test-node-selectors-srl1",
                     "clabernetes/topologyNode": "srl1",
                     "clabernetes/topologyOwner": "render-deployment-test-node-selectors"
+                },
+                "annotations": {
+                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/simple.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/simple.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/with-link-attachments.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/with-link-attachments.json
@@ -10,7 +10,7 @@
             "clabernetes/topologyOwner": "render-deployment-test"
         },
         "annotations": {
-            "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            "clabernetes/linkAttachmentsDigest": "8d28fb95b7a7ee3167cff74ab454676361868207515c50af5f204f515a7ee93f"
         }
     },
     "spec": {
@@ -34,7 +34,7 @@
                     "clabernetes/topologyOwner": "render-deployment-test"
                 },
                 "annotations": {
-                    "clabernetes/linkAttachmentsDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    "clabernetes/linkAttachmentsDigest": "8d28fb95b7a7ee3167cff74ab454676361868207515c50af5f204f515a7ee93f"
                 }
             },
             "spec": {

--- a/controllers/topology/test-fixtures/golden/deployment/render-deployment/with-link-attachments.json
+++ b/controllers/topology/test-fixtures/golden/deployment/render-deployment/with-link-attachments.json
@@ -129,6 +129,14 @@
                                 "value": "vxlan"
                             },
                             {
+                                "name": "LAUNCHER_TOPOLOGY_REMOVE_PREFIX",
+                                "value": "false"
+                            },
+                            {
+                                "name": "LAUNCHER_IN_CLUSTER_DNS_SUFFIX",
+                                "value": "svc.cluster.local"
+                            },
+                            {
                                 "name": "LAUNCHER_CONTAINERLAB_VERSION"
                             },
                             {

--- a/controllers/topology/test-fixtures/golden/linkcr/render-links/grouped-nodes.json
+++ b/controllers/topology/test-fixtures/golden/linkcr/render-links/grouped-nodes.json
@@ -16,15 +16,11 @@
             "topologyName": "render-links-test",
             "endpointA": {
                 "nodeName": "srl1a",
-                "interfaceName": "e1-1",
-                "launcherNode": "srl1",
-                "destination": "render-links-test-srl1-vx.clabernetes.svc.cluster.local"
+                "interfaceName": "e1-1"
             },
             "endpointB": {
                 "nodeName": "srl2",
-                "interfaceName": "e1-1",
-                "launcherNode": "srl2",
-                "destination": "render-links-test-srl2-vx.clabernetes.svc.cluster.local"
+                "interfaceName": "e1-1"
             },
             "tunnelID": 0
         },

--- a/controllers/topology/test-fixtures/golden/linkcr/render-links/grouped-nodes.json
+++ b/controllers/topology/test-fixtures/golden/linkcr/render-links/grouped-nodes.json
@@ -21,8 +21,7 @@
             "endpointB": {
                 "nodeName": "srl2",
                 "interfaceName": "e1-1"
-            },
-            "tunnelID": 0
+            }
         },
         "status": {}
     }

--- a/controllers/topology/test-fixtures/golden/linkcr/render-links/simple.json
+++ b/controllers/topology/test-fixtures/golden/linkcr/render-links/simple.json
@@ -16,15 +16,11 @@
             "topologyName": "render-links-test",
             "endpointA": {
                 "nodeName": "srl1",
-                "interfaceName": "e1-1",
-                "launcherNode": "srl1",
-                "destination": "render-links-test-srl1-vx.clabernetes.svc.cluster.local"
+                "interfaceName": "e1-1"
             },
             "endpointB": {
                 "nodeName": "srl2",
-                "interfaceName": "e1-1",
-                "launcherNode": "srl2",
-                "destination": "render-links-test-srl2-vx.clabernetes.svc.cluster.local"
+                "interfaceName": "e1-1"
             },
             "tunnelID": 0
         },

--- a/controllers/topology/test-fixtures/golden/linkcr/render-links/simple.json
+++ b/controllers/topology/test-fixtures/golden/linkcr/render-links/simple.json
@@ -21,8 +21,7 @@
             "endpointB": {
                 "nodeName": "srl2",
                 "interfaceName": "e1-1"
-            },
-            "tunnelID": 0
+            }
         },
         "status": {}
     }

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -1,11 +1,8 @@
 package topology
 
 import (
-	"fmt"
-
 	clabernetesapis "github.com/srl-labs/clabernetes/apis"
 	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
-	clabernetesconfig "github.com/srl-labs/clabernetes/config"
 )
 
 // GetTopologyKind returns the "kind" of topology this CR represents -- typically this will be
@@ -43,32 +40,4 @@ func ResolveTopologyRemovePrefix(t *clabernetesapisv1alpha1.Topology) bool {
 	}
 
 	return *t.Status.RemoveTopologyPrefix
-}
-
-func resolveConnectivityDestination(
-	topologyName,
-	uninterestingEndpointNodeName,
-	namespace string,
-	removeTopologyPrefix bool,
-	// inject config manager getter so we can easily test this (and things upstream)
-	configManagerGetter clabernetesconfig.ManagerGetterFunc,
-) string {
-	destination := fmt.Sprintf(
-		"%s-%s-vx.%s.%s",
-		topologyName,
-		uninterestingEndpointNodeName,
-		namespace,
-		configManagerGetter().GetInClusterDNSSuffix(),
-	)
-
-	if removeTopologyPrefix {
-		destination = fmt.Sprintf(
-			"%s-vx.%s.%s",
-			uninterestingEndpointNodeName,
-			namespace,
-			configManagerGetter().GetInClusterDNSSuffix(),
-		)
-	}
-
-	return destination
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,8 +78,11 @@ the clabernetes launcher fetches "its" `Node` custom resource -- the controller 
 resource per node of the topology holding that node's "sub-topology" -- then handles any initial
 setup, and finally launches "normal" containerlab with a topology file representing *one node
 from the original topology*. This removes the previous topology-wide amplification: a Node only
-contains its launcher group's nodes and links. High-degree or large grouped nodes still produce
-larger Node objects, so scale validation should measure the largest Node as well as the aggregate.
+contains its launcher group's nodes and node-local links (user defined host links and links
+between grouped nodes). Links between launchers live on Link resources instead -- the launcher
+synthesizes the local "node <-> host" plumbing stanzas for those into its topology file at
+startup -- so a Node object does not grow with link degree, only with the size of its launcher
+group. Scale validation should still measure the largest Node as well as the aggregate.
 
 **Note:** that this is not "normal" docker-in-docker as we aren't actually mounting the docker sock
 in the container -- this is a full-blown docker installation independent of the CRI of your cluster.

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -594,13 +594,16 @@ spec:
   endpointB:
     nodeName: srl2
     interfaceName: e1-1
+status:
   tunnelID: 1
 ```
 
-The `clabernetes/linkEndpointA`/`clabernetes/linkEndpointB` labels hold the launcher node that
-terminates each side of the link (the primary node for grouped nodes) -- launchers derive the
-remote fabric service name (`<topology>-<launcherNode>-vx`) from the label, so no in-cluster DNS
-names need to be persisted on the resource.
+The spec holds only the wire as the user drew it. Everything operational is stamped by the
+controller: the `clabernetes/linkEndpointA`/`clabernetes/linkEndpointB` labels hold the launcher
+node that terminates each side of the link (the primary node for grouped nodes) -- launchers
+derive the remote fabric service name (`<topology>-<launcherNode>-vx`) from the label, so no
+in-cluster DNS names need to be persisted -- and the tunnel id is an allocation the controller
+writes to the status.
 
 ### LinkSpec Fields
 
@@ -609,8 +612,13 @@ names need to be persisted on the resource.
 | `topologyName` | string | Name of the owning Topology |
 | `endpointA` | LinkEndpointSpec | The "a" side of the link |
 | `endpointB` | LinkEndpointSpec | The "b" side of the link |
-| `tunnelID` | int | Tunnel ID (VNID or segment ID), shared by both sides |
 | `mtu` | int | MTU from the original topology link definition (0 = containerlab default) |
+
+### LinkStatus Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tunnelID` | int | Tunnel ID (VNID or segment ID) allocated by the controller, shared by both sides (0 = not allocated yet) |
 
 ##### LinkEndpointSpec
 

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -591,15 +591,16 @@ spec:
   endpointA:
     nodeName: srl1
     interfaceName: e1-1
-    launcherNode: srl1
-    destination: my-topology-srl1-vx.default.svc.cluster.local
   endpointB:
     nodeName: srl2
     interfaceName: e1-1
-    launcherNode: srl2
-    destination: my-topology-srl2-vx.default.svc.cluster.local
   tunnelID: 1
 ```
+
+The `clabernetes/linkEndpointA`/`clabernetes/linkEndpointB` labels hold the launcher node that
+terminates each side of the link (the primary node for grouped nodes) -- launchers derive the
+remote fabric service name (`<topology>-<launcherNode>-vx`) from the label, so no in-cluster DNS
+names need to be persisted on the resource.
 
 ### LinkSpec Fields
 
@@ -617,8 +618,6 @@ spec:
 |-------|------|-------------|
 | `nodeName` | string | Node name this side of the link resides on |
 | `interfaceName` | string | Interface name on the node |
-| `launcherNode` | string | Node whose launcher pod terminates this side (primary node for grouped nodes) |
-| `destination` | string | Service FQDN via which this side can be reached |
 
 ---
 

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -528,7 +528,7 @@ status:
 |-------|------|-------------|
 | `topologyName` | string | Name of the owning Topology |
 | `nodeName` | string | Node name in the topology (primary node for grouped nodes) |
-| `config` | string | Rendered containerlab sub-topology for this node |
+| `config` | string | Rendered containerlab sub-topology for this node -- node things only (nodes, kinds, defaults, and node-local links); cross-launcher links live on Link resources, launchers synthesize the local plumbing for them |
 | `filesFromURL` | []FileFromURL | Files the launcher fetches before starting the node |
 | `imagePullSecrets` | []string | Pull secrets the launcher may use via the cluster CRI |
 
@@ -609,6 +609,7 @@ spec:
 | `endpointA` | LinkEndpointSpec | The "a" side of the link |
 | `endpointB` | LinkEndpointSpec | The "b" side of the link |
 | `tunnelID` | int | Tunnel ID (VNID or segment ID), shared by both sides |
+| `mtu` | int | MTU from the original topology link definition (0 = containerlab default) |
 
 ##### LinkEndpointSpec
 

--- a/e2e/topology/basic/test-fixtures/golden/10-deployment.topology-basic-srl1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/10-deployment.topology-basic-srl1.yaml
@@ -68,7 +68,7 @@ spec:
             - name: LAUNCHER_IMAGE_PULL_THROUGH_MODE
               value: auto
             - name: LAUNCHER_LOGGER_LEVEL
-              value: debug
+              value: info
             - name: LAUNCHER_TOPOLOGY_NAME
               value: topology-basic
             - name: LAUNCHER_NODE_NAME
@@ -77,6 +77,10 @@ spec:
               value: ghcr.io/nokia/srlinux
             - name: LAUNCHER_CONNECTIVITY_KIND
               value: vxlan
+            - name: LAUNCHER_TOPOLOGY_REMOVE_PREFIX
+              value: "false"
+            - name: LAUNCHER_IN_CLUSTER_DNS_SUFFIX
+              value: svc.cluster.local
             - name: LAUNCHER_CONTAINERLAB_VERSION
             - name: LAUNCHER_CONTAINERLAB_TIMEOUT
             - name: LAUNCHER_PRIVILEGED

--- a/e2e/topology/basic/test-fixtures/golden/10-deployment.topology-basic-srl1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/10-deployment.topology-basic-srl1.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations: {}
+  annotations:
+    clabernetes/linkAttachmentsDigest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   labels:
     app.kubernetes.io/name: topology-basic-srl1
     clabernetes/app: clabernetes
@@ -29,6 +30,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        clabernetes/linkAttachmentsDigest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       labels:
         app.kubernetes.io/name: topology-basic-srl1
         clabernetes/app: clabernetes

--- a/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl1.yaml
@@ -68,7 +68,7 @@ spec:
             - name: LAUNCHER_IMAGE_PULL_THROUGH_MODE
               value: auto
             - name: LAUNCHER_LOGGER_LEVEL
-              value: debug
+              value: info
             - name: LAUNCHER_TOPOLOGY_NAME
               value: topology-basic
             - name: LAUNCHER_NODE_NAME
@@ -77,6 +77,10 @@ spec:
               value: ghcr.io/nokia/srlinux
             - name: LAUNCHER_CONNECTIVITY_KIND
               value: vxlan
+            - name: LAUNCHER_TOPOLOGY_REMOVE_PREFIX
+              value: "false"
+            - name: LAUNCHER_IN_CLUSTER_DNS_SUFFIX
+              value: svc.cluster.local
             - name: LAUNCHER_CONTAINERLAB_VERSION
             - name: LAUNCHER_CONTAINERLAB_TIMEOUT
             - name: LAUNCHER_PRIVILEGED

--- a/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl1.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations: {}
+  annotations:
+    clabernetes/linkAttachmentsDigest: 8d28fb95b7a7ee3167cff74ab454676361868207515c50af5f204f515a7ee93f
   labels:
     app.kubernetes.io/name: topology-basic-srl1
     clabernetes/app: clabernetes
@@ -29,7 +30,8 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations: {}
+      annotations:
+        clabernetes/linkAttachmentsDigest: 8d28fb95b7a7ee3167cff74ab454676361868207515c50af5f204f515a7ee93f
       labels:
         app.kubernetes.io/name: topology-basic-srl1
         clabernetes/app: clabernetes

--- a/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl2.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl2.yaml
@@ -68,7 +68,7 @@ spec:
             - name: LAUNCHER_IMAGE_PULL_THROUGH_MODE
               value: auto
             - name: LAUNCHER_LOGGER_LEVEL
-              value: debug
+              value: info
             - name: LAUNCHER_TOPOLOGY_NAME
               value: topology-basic
             - name: LAUNCHER_NODE_NAME
@@ -77,6 +77,10 @@ spec:
               value: ghcr.io/nokia/srlinux
             - name: LAUNCHER_CONNECTIVITY_KIND
               value: vxlan
+            - name: LAUNCHER_TOPOLOGY_REMOVE_PREFIX
+              value: "false"
+            - name: LAUNCHER_IN_CLUSTER_DNS_SUFFIX
+              value: svc.cluster.local
             - name: LAUNCHER_CONTAINERLAB_VERSION
             - name: LAUNCHER_CONTAINERLAB_TIMEOUT
             - name: LAUNCHER_PRIVILEGED

--- a/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl2.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-deployment.topology-basic-srl2.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations: {}
+  annotations:
+    clabernetes/linkAttachmentsDigest: e0230ba4ef459d06790d99f51aa722af1a8ce1392e4da1fd36c1385d3eb59947
   labels:
     app.kubernetes.io/name: topology-basic-srl2
     clabernetes/app: clabernetes
@@ -29,6 +30,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        clabernetes/linkAttachmentsDigest: e0230ba4ef459d06790d99f51aa722af1a8ce1392e4da1fd36c1385d3eb59947
       labels:
         app.kubernetes.io/name: topology-basic-srl2
         clabernetes/app: clabernetes

--- a/e2e/topology/basic/test-fixtures/golden/20-link.clabernetes.containerlab.dev.topology-basic-srl1-e1-1-srl2-e1-1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-link.clabernetes.containerlab.dev.topology-basic-srl1-e1-1-srl2-e1-1.yaml
@@ -16,14 +16,10 @@ metadata:
       name: topology-basic
 spec:
   endpointA:
-    destination: topology-basic-srl1-vx.NAMESPACE.svc.cluster.local
     interfaceName: e1-1
-    launcherNode: srl1
     nodeName: srl1
   endpointB:
-    destination: topology-basic-srl2-vx.NAMESPACE.svc.cluster.local
     interfaceName: e1-1
-    launcherNode: srl2
     nodeName: srl2
   topologyName: topology-basic
   tunnelID: 1

--- a/e2e/topology/basic/test-fixtures/golden/20-link.clabernetes.containerlab.dev.topology-basic-srl1-e1-1-srl2-e1-1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-link.clabernetes.containerlab.dev.topology-basic-srl1-e1-1-srl2-e1-1.yaml
@@ -22,5 +22,5 @@ spec:
     interfaceName: e1-1
     nodeName: srl2
   topologyName: topology-basic
+status:
   tunnelID: 1
-status: {}

--- a/e2e/topology/basic/test-fixtures/golden/20-node.clabernetes.containerlab.dev.topology-basic-srl1.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-node.clabernetes.containerlab.dev.topology-basic-srl1.yaml
@@ -41,9 +41,6 @@ spec:
                 ports: []
         links:
             - endpoints:
-                - srl1:e1-1
-                - host:srl1-e1-1
-            - endpoints:
                 - srl1:e1-3
                 - host:eth13
     debug: false

--- a/e2e/topology/basic/test-fixtures/golden/20-node.clabernetes.containerlab.dev.topology-basic-srl2.yaml
+++ b/e2e/topology/basic/test-fixtures/golden/20-node.clabernetes.containerlab.dev.topology-basic-srl2.yaml
@@ -39,10 +39,6 @@ spec:
                 kind: srl
                 image: ghcr.io/nokia/srlinux
                 ports: []
-        links:
-            - endpoints:
-                - srl2:e1-1
-                - host:srl2-e1-1
     debug: false
   nodeName: srl2
   topologyName: topology-basic

--- a/generated/openapi/openapi.json
+++ b/generated/openapi/openapi.json
@@ -1788,7 +1788,7 @@
                 }
             },
             "clabernetes-containerlab-dev.link.v1alpha1": {
-                "description": "Link is an object that represents a single point-to-point link between two (containerlab) nodes\nof a clabernetes Topology. Links are created and managed by the clabernetes controller -- one\nper inter-launcher link -- and hold everything both launcher pods need to establish the tunnel\n(vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big\nconnectivity object) means no single object grows with the size of the topology, which keeps\nclabernetes clear of the etcd max object size limits for very large topologies.",
+                "description": "Link is an object that represents a single point-to-point link between two (containerlab) nodes\nof a clabernetes Topology. Links are created and managed by the clabernetes controller -- one\nper inter-launcher link -- and hold everything both launcher pods need to establish the tunnel\n(vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big\nconnectivity object) means no single object grows with the size of the topology, which keeps\nclabernetes clear of the etcd max object size limits for very large topologies. The\n\"clabernetes/linkEndpointA\" and \"clabernetes/linkEndpointB\" labels hold the launcher nodes\nthat terminate each side (the primary node for grouped nodes) -- launchers select \"their\"\nlinks by those labels and derive the remote fabric service from them.",
                 "properties": {
                     "apiVersion": {
                         "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1807,16 +1807,8 @@
                             "endpointA": {
                                 "description": "EndpointA is the \"a\" side of this link.",
                                 "properties": {
-                                    "destination": {
-                                        "description": "Destination is the qualified kubernetes service name over which this side of the link can\nbe reached (that is, the service the *other* side of the link connects to).",
-                                        "type": "string"
-                                    },
                                     "interfaceName": {
                                         "description": "InterfaceName is the name of the interface on the node this side of the link is on.",
-                                        "type": "string"
-                                    },
-                                    "launcherNode": {
-                                        "description": "LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side\nof the link -- for \"grouped\" nodes this is the primary node of the group, otherwise this is\nsimply the same as NodeName.",
                                         "type": "string"
                                     },
                                     "nodeName": {
@@ -1825,9 +1817,7 @@
                                     }
                                 },
                                 "required": [
-                                    "destination",
                                     "interfaceName",
-                                    "launcherNode",
                                     "nodeName"
                                 ],
                                 "type": "object"
@@ -1835,16 +1825,8 @@
                             "endpointB": {
                                 "description": "EndpointB is the \"b\" side of this link.",
                                 "properties": {
-                                    "destination": {
-                                        "description": "Destination is the qualified kubernetes service name over which this side of the link can\nbe reached (that is, the service the *other* side of the link connects to).",
-                                        "type": "string"
-                                    },
                                     "interfaceName": {
                                         "description": "InterfaceName is the name of the interface on the node this side of the link is on.",
-                                        "type": "string"
-                                    },
-                                    "launcherNode": {
-                                        "description": "LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side\nof the link -- for \"grouped\" nodes this is the primary node of the group, otherwise this is\nsimply the same as NodeName.",
                                         "type": "string"
                                     },
                                     "nodeName": {
@@ -1853,9 +1835,7 @@
                                     }
                                 },
                                 "required": [
-                                    "destination",
                                     "interfaceName",
-                                    "launcherNode",
                                     "nodeName"
                                 ],
                                 "type": "object"

--- a/generated/openapi/openapi.json
+++ b/generated/openapi/openapi.json
@@ -1860,6 +1860,10 @@
                                 ],
                                 "type": "object"
                             },
+                            "mtu": {
+                                "description": "MTU is the mtu for the link as set in the original topology definition -- launchers apply\nthis to the (node side of the) link termination they create; zero means \"unset\" (use the\ncontainerlab default).",
+                                "type": "integer"
+                            },
                             "topologyName": {
                                 "description": "TopologyName is the name of the Topology this Link belongs to.",
                                 "type": "string"

--- a/generated/openapi/openapi.json
+++ b/generated/openapi/openapi.json
@@ -1802,7 +1802,7 @@
                         "type": "object"
                     },
                     "spec": {
-                        "description": "LinkSpec is the spec for a Link resource.",
+                        "description": "LinkSpec is the spec for a Link resource. It holds only the \"wire as the user drew it\" --\nanything operational (like the allocated tunnel id) lives in the status or is derived by the\nlaunchers.",
                         "properties": {
                             "endpointA": {
                                 "description": "EndpointA is the \"a\" side of this link.",
@@ -1847,24 +1847,25 @@
                             "topologyName": {
                                 "description": "TopologyName is the name of the Topology this Link belongs to.",
                                 "type": "string"
-                            },
-                            "tunnelID": {
-                                "description": "TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of\nthe link use the same id.",
-                                "maximum": 16000000,
-                                "minimum": 1,
-                                "type": "integer"
                             }
                         },
                         "required": [
                             "endpointA",
                             "endpointB",
-                            "topologyName",
-                            "tunnelID"
+                            "topologyName"
                         ],
                         "type": "object"
                     },
                     "status": {
                         "description": "LinkStatus is the status for a Link resource.",
+                        "properties": {
+                            "tunnelID": {
+                                "description": "TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for\nthis link -- both sides of the link use the same id. This is an allocation rather than user\nintent, hence it living in the status; zero means \"not allocated yet\" (launchers skip such\nlinks until the controller has filled the id in).",
+                                "maximum": 16000000,
+                                "minimum": 0,
+                                "type": "integer"
+                            }
+                        },
                         "type": "object"
                     }
                 },

--- a/generated/openapi/openapi_generated.go
+++ b/generated/openapi/openapi_generated.go
@@ -1402,7 +1402,7 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_LinkSpec(
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "LinkSpec is the spec for a Link resource.",
+				Description: "LinkSpec is the spec for a Link resource. It holds only the \"wire as the user drew it\" -- anything operational (like the allocated tunnel id) lives in the status or is derived by the launchers.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"topologyName": {
@@ -1431,14 +1431,6 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_LinkSpec(
 							),
 						},
 					},
-					"tunnelID": {
-						SchemaProps: spec.SchemaProps{
-							Description: "TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of the link use the same id.",
-							Default:     0,
-							Type:        []string{"integer"},
-							Format:      "int32",
-						},
-					},
 					"mtu": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MTU is the mtu for the link as set in the original topology definition -- launchers apply this to the (node side of the) link termination they create; zero means \"unset\" (use the containerlab default).",
@@ -1447,7 +1439,7 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_LinkSpec(
 						},
 					},
 				},
-				Required: []string{"topologyName", "endpointA", "endpointB", "tunnelID"},
+				Required: []string{"topologyName", "endpointA", "endpointB"},
 			},
 		},
 		Dependencies: []string{
@@ -1463,6 +1455,15 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_LinkStatus(
 			SchemaProps: spec.SchemaProps{
 				Description: "LinkStatus is the status for a Link resource.",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"tunnelID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for this link -- both sides of the link use the same id. This is an allocation rather than user intent, hence it living in the status; zero means \"not allocated yet\" (launchers skip such links until the controller has filled the id in).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/generated/openapi/openapi_generated.go
+++ b/generated/openapi/openapi_generated.go
@@ -1455,6 +1455,13 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_LinkSpec(
 							Format:      "int32",
 						},
 					},
+					"mtu": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MTU is the mtu for the link as set in the original topology definition -- launchers apply this to the (node side of the) link termination they create; zero means \"unset\" (use the containerlab default).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"topologyName", "endpointA", "endpointB", "tunnelID"},
 			},
@@ -1834,6 +1841,13 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_PointToPointTunnel(
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"mtu": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MTU is the mtu for the link this tunnel realizes; zero means \"unset\" (use the containerlab default).",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},

--- a/generated/openapi/openapi_generated.go
+++ b/generated/openapi/openapi_generated.go
@@ -1235,7 +1235,7 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_Link(
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Link is an object that represents a single point-to-point link between two (containerlab) nodes of a clabernetes Topology. Links are created and managed by the clabernetes controller -- one per inter-launcher link -- and hold everything both launcher pods need to establish the tunnel (vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big connectivity object) means no single object grows with the size of the topology, which keeps clabernetes clear of the etcd max object size limits for very large topologies.",
+				Description: "Link is an object that represents a single point-to-point link between two (containerlab) nodes of a clabernetes Topology. Links are created and managed by the clabernetes controller -- one per inter-launcher link -- and hold everything both launcher pods need to establish the tunnel (vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big connectivity object) means no single object grows with the size of the topology, which keeps clabernetes clear of the etcd max object size limits for very large topologies. The \"clabernetes/linkEndpointA\" and \"clabernetes/linkEndpointB\" labels hold the launcher nodes that terminate each side (the primary node for grouped nodes) -- launchers select \"their\" links by those labels and derive the remote fabric service from them.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -1337,24 +1337,8 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_LinkEndpointSpec(
 							Format:      "",
 						},
 					},
-					"launcherNode": {
-						SchemaProps: spec.SchemaProps{
-							Description: "LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side of the link -- for \"grouped\" nodes this is the primary node of the group, otherwise this is simply the same as NodeName.",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"destination": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Destination is the qualified kubernetes service name over which this side of the link can be reached (that is, the service the *other* side of the link connects to).",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 				},
-				Required: []string{"nodeName", "interfaceName", "launcherNode", "destination"},
+				Required: []string{"nodeName", "interfaceName"},
 			},
 		},
 	}
@@ -1805,8 +1789,7 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_PointToPointTunnel(
 					},
 					"destination": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Destination is the destination service to connect to (qualified k8s service name).",
-							Default:     "",
+							Description: "Destination is the destination service to connect to (qualified k8s service name) -- launchers derive this from the link's topology name and the remote launcher node (which they read from the link's endpoint labels).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1853,7 +1836,6 @@ func schema_srl_labs_clabernetes_apis_v1alpha1_PointToPointTunnel(
 				},
 				Required: []string{
 					"tunnelID",
-					"destination",
 					"localNode",
 					"localInterface",
 					"remoteNode",

--- a/launcher/clabernetes.go
+++ b/launcher/clabernetes.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
 	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
 	clabernetesgeneratedclientset "github.com/srl-labs/clabernetes/generated/clientset"
 	claberneteslogging "github.com/srl-labs/clabernetes/logging"
@@ -101,6 +102,11 @@ type clabernetes struct {
 	// meanwhile nodeContainerID is the container id of hte specific node this launcher represents
 	// -- meaning the single node from the original topology this launcher is representing
 	nodeContainerID string
+
+	// initialTunnels holds the local tunnel view listed while materializing the topology -- the
+	// same snapshot seeds the connectivity manager so the tunnels it establishes line up with the
+	// link stanzas (and therefore host side veths) of the deployed topology.
+	initialTunnels []*clabernetesapisv1alpha1.PointToPointTunnel
 }
 
 func (c *clabernetes) startup() {

--- a/launcher/connectivity.go
+++ b/launcher/connectivity.go
@@ -10,17 +10,15 @@ import (
 )
 
 func (c *clabernetes) connectivity() {
-	tunnels, err := c.getTunnels()
-	if err != nil {
-		c.logger.Fatalf("failed loading tunnels content, err: %s", err)
-	}
-
+	// the initial tunnels were listed during node resource fetch so the deployed topology and the
+	// initial tunnel view are guaranteed to line up; the manager watches link crs for updates
+	// from there on
 	connectivityManager, err := claberneteslauncherconnectivity.NewManager(
 		c.ctx,
 		nil,
 		c.logger,
 		c.kubeClabernetesClient,
-		tunnels,
+		c.initialTunnels,
 		os.Getenv(
 			clabernetesconstants.LauncherConnectivityKind,
 		),

--- a/launcher/connectivity/tunnel_test.go
+++ b/launcher/connectivity/tunnel_test.go
@@ -29,8 +29,10 @@ func testLink() *clabernetesapisv1alpha1.Link {
 				NodeName:      "srl2",
 				InterfaceName: "e1-1",
 			},
+			MTU: 9212,
+		},
+		Status: clabernetesapisv1alpha1.LinkStatus{
 			TunnelID: 101,
-			MTU:      9212,
 		},
 	}
 }

--- a/launcher/connectivity/tunnel_test.go
+++ b/launcher/connectivity/tunnel_test.go
@@ -1,0 +1,125 @@
+package connectivity //nolint:testpackage // tests exercise the unexported link -> tunnel helpers
+
+import (
+	"reflect"
+	"testing"
+
+	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
+	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testLink() *clabernetesapisv1alpha1.Link {
+	return &clabernetesapisv1alpha1.Link{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "topo-srl1-e1-1-srl2-e1-1",
+			Namespace: "clabernetes",
+			Labels: map[string]string{
+				clabernetesconstants.LabelLinkEndpointA: "srl1",
+				clabernetesconstants.LabelLinkEndpointB: "srl2",
+			},
+		},
+		Spec: clabernetesapisv1alpha1.LinkSpec{
+			TopologyName: "topo",
+			EndpointA: clabernetesapisv1alpha1.LinkEndpointSpec{
+				NodeName:      "srl1",
+				InterfaceName: "e1-1",
+			},
+			EndpointB: clabernetesapisv1alpha1.LinkEndpointSpec{
+				NodeName:      "srl2",
+				InterfaceName: "e1-1",
+			},
+			TunnelID: 101,
+			MTU:      9212,
+		},
+	}
+}
+
+func TestLinkToLocalTunnel(t *testing.T) {
+	tests := []struct {
+		name             string
+		nodeName         string
+		removePrefix     string
+		dnsSuffix        string
+		expectedTunnel   *clabernetesapisv1alpha1.PointToPointTunnel
+		expectedDestName string
+	}{
+		{
+			name:     "a-side-local",
+			nodeName: "srl1",
+			expectedTunnel: &clabernetesapisv1alpha1.PointToPointTunnel{
+				TunnelID:        101,
+				Destination:     "topo-srl2-vx.clabernetes.svc.cluster.local",
+				LocalNode:       "srl1",
+				LocalInterface:  "e1-1",
+				RemoteNode:      "srl2",
+				RemoteInterface: "e1-1",
+				MTU:             9212,
+			},
+		},
+		{
+			name:     "b-side-local",
+			nodeName: "srl2",
+			expectedTunnel: &clabernetesapisv1alpha1.PointToPointTunnel{
+				TunnelID:        101,
+				Destination:     "topo-srl1-vx.clabernetes.svc.cluster.local",
+				LocalNode:       "srl2",
+				LocalInterface:  "e1-1",
+				RemoteNode:      "srl1",
+				RemoteInterface: "e1-1",
+				MTU:             9212,
+			},
+		},
+		{
+			name:         "remove-topology-prefix",
+			nodeName:     "srl1",
+			removePrefix: "true",
+			expectedTunnel: &clabernetesapisv1alpha1.PointToPointTunnel{
+				TunnelID:        101,
+				Destination:     "srl2-vx.clabernetes.svc.cluster.local",
+				LocalNode:       "srl1",
+				LocalInterface:  "e1-1",
+				RemoteNode:      "srl2",
+				RemoteInterface: "e1-1",
+				MTU:             9212,
+			},
+		},
+		{
+			name:      "custom-dns-suffix",
+			nodeName:  "srl1",
+			dnsSuffix: "svc.some.domain",
+			expectedTunnel: &clabernetesapisv1alpha1.PointToPointTunnel{
+				TunnelID:        101,
+				Destination:     "topo-srl2-vx.clabernetes.svc.some.domain",
+				LocalNode:       "srl1",
+				LocalInterface:  "e1-1",
+				RemoteNode:      "srl2",
+				RemoteInterface: "e1-1",
+				MTU:             9212,
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv(
+				clabernetesconstants.LauncherTopologyRemovePrefixEnv,
+				testCase.removePrefix,
+			)
+			t.Setenv(
+				clabernetesconstants.LauncherInClusterDNSSuffixEnv,
+				testCase.dnsSuffix,
+			)
+
+			got := linkToLocalTunnel(testCase.nodeName, testLink())
+
+			if !reflect.DeepEqual(got, testCase.expectedTunnel) {
+				t.Fatalf(
+					"local tunnel view does not match expectation\ngot: %+v\nwant: %+v",
+					got,
+					testCase.expectedTunnel,
+				)
+			}
+		})
+	}
+}

--- a/launcher/connectivity/watch.go
+++ b/launcher/connectivity/watch.go
@@ -57,6 +57,7 @@ func linkToLocalTunnel(
 		LocalInterface:  local.InterfaceName,
 		RemoteNode:      remote.NodeName,
 		RemoteInterface: remote.InterfaceName,
+		MTU:             link.Spec.MTU,
 	}
 }
 

--- a/launcher/connectivity/watch.go
+++ b/launcher/connectivity/watch.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
 	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
 	clabernetesgeneratedclientset "github.com/srl-labs/clabernetes/generated/clientset"
 	claberneteslogging "github.com/srl-labs/clabernetes/logging"
+	clabernetesutil "github.com/srl-labs/clabernetes/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerywatch "k8s.io/apimachinery/pkg/watch"
 )
@@ -39,20 +41,49 @@ func nodeLinkSelectors(topologyName, nodeName string) []string {
 	}
 }
 
+// linkDestination returns the qualified service name of the remote launcher's fabric service --
+// this is derived rather than persisted on the link cr: the service name follows directly from
+// the topology name and the remote launcher node, the namespace is the link's own namespace, and
+// the topology prefix / dns suffix knobs come down from the controller via the launcher env.
+func linkDestination(link *clabernetesapisv1alpha1.Link, remoteLauncherNode string) string {
+	serviceName := fmt.Sprintf("%s-%s-vx", link.Spec.TopologyName, remoteLauncherNode)
+
+	if strings.EqualFold(
+		os.Getenv(clabernetesconstants.LauncherTopologyRemovePrefixEnv),
+		clabernetesconstants.True,
+	) {
+		serviceName = fmt.Sprintf("%s-vx", remoteLauncherNode)
+	}
+
+	return fmt.Sprintf(
+		"%s.%s.%s",
+		serviceName,
+		link.GetNamespace(),
+		clabernetesutil.GetEnvStrOrDefault(
+			clabernetesconstants.LauncherInClusterDNSSuffixEnv,
+			clabernetesconstants.KubernetesDefaultInClusterDNSSuffix,
+		),
+	)
+}
+
 // linkToLocalTunnel converts a link cr to the "local view" tunnel for the given (launcher) node.
+// Which side is local (and which launcher node terminates the remote side) comes from the link's
+// endpoint labels.
 func linkToLocalTunnel(
 	nodeName string,
 	link *clabernetesapisv1alpha1.Link,
 ) *clabernetesapisv1alpha1.PointToPointTunnel {
 	local, remote := link.Spec.EndpointA, link.Spec.EndpointB
+	remoteLauncherNode := link.GetLabels()[clabernetesconstants.LabelLinkEndpointB]
 
-	if link.Spec.EndpointB.LauncherNode == nodeName {
+	if link.GetLabels()[clabernetesconstants.LabelLinkEndpointB] == nodeName {
 		local, remote = remote, local
+		remoteLauncherNode = link.GetLabels()[clabernetesconstants.LabelLinkEndpointA]
 	}
 
 	return &clabernetesapisv1alpha1.PointToPointTunnel{
 		TunnelID:        link.Spec.TunnelID,
-		Destination:     remote.Destination,
+		Destination:     linkDestination(link, remoteLauncherNode),
 		LocalNode:       local.NodeName,
 		LocalInterface:  local.InterfaceName,
 		RemoteNode:      remote.NodeName,

--- a/launcher/connectivity/watch.go
+++ b/launcher/connectivity/watch.go
@@ -82,7 +82,7 @@ func linkToLocalTunnel(
 	}
 
 	return &clabernetesapisv1alpha1.PointToPointTunnel{
-		TunnelID:        link.Spec.TunnelID,
+		TunnelID:        link.Status.TunnelID,
 		Destination:     linkDestination(link, remoteLauncherNode),
 		LocalNode:       local.NodeName,
 		LocalInterface:  local.InterfaceName,
@@ -119,6 +119,12 @@ func ListNodeTunnels(
 			}
 
 			seenLinks[links.Items[i].Name] = true
+
+			if links.Items[i].Status.TunnelID == 0 {
+				// the controller has not allocated a tunnel id for this link (yet) -- skip it,
+				// the watch fires again once the status is filled in
+				continue
+			}
 
 			tunnels = append(tunnels, linkToLocalTunnel(nodeName, &links.Items[i]))
 		}

--- a/launcher/connectivity/watch_test.go
+++ b/launcher/connectivity/watch_test.go
@@ -50,7 +50,7 @@ func (h *initialListWatchGapHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		resourceVersion = "2"
 
 		if strings.Contains(selector, "linkEndpointA") {
-			items = `{"apiVersion":"clabernetes.containerlab.dev/v1alpha1","kind":"Link","metadata":{"name":"link-1","labels":{"clabernetes/linkEndpointA":"r1","clabernetes/linkEndpointB":"r2"}},"spec":{"topologyName":"topology","endpointA":{"nodeName":"r1","interfaceName":"e1"},"endpointB":{"nodeName":"r2","interfaceName":"e1"},"tunnelID":1}}`
+			items = `{"apiVersion":"clabernetes.containerlab.dev/v1alpha1","kind":"Link","metadata":{"name":"link-1","labels":{"clabernetes/linkEndpointA":"r1","clabernetes/linkEndpointB":"r2"}},"spec":{"topologyName":"topology","endpointA":{"nodeName":"r1","interfaceName":"e1"},"endpointB":{"nodeName":"r2","interfaceName":"e1"}},"status":{"tunnelID":1}}`
 		}
 	}
 

--- a/launcher/connectivity/watch_test.go
+++ b/launcher/connectivity/watch_test.go
@@ -50,7 +50,7 @@ func (h *initialListWatchGapHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		resourceVersion = "2"
 
 		if strings.Contains(selector, "linkEndpointA") {
-			items = `{"apiVersion":"clabernetes.containerlab.dev/v1alpha1","kind":"Link","metadata":{"name":"link-1"},"spec":{"topologyName":"topology","endpointA":{"nodeName":"r1","interfaceName":"e1","launcherNode":"r1","destination":"r1"},"endpointB":{"nodeName":"r2","interfaceName":"e1","launcherNode":"r2","destination":"r2"},"tunnelID":1}}`
+			items = `{"apiVersion":"clabernetes.containerlab.dev/v1alpha1","kind":"Link","metadata":{"name":"link-1","labels":{"clabernetes/linkEndpointA":"r1","clabernetes/linkEndpointB":"r2"}},"spec":{"topologyName":"topology","endpointA":{"nodeName":"r1","interfaceName":"e1"},"endpointB":{"nodeName":"r2","interfaceName":"e1"},"tunnelID":1}}`
 		}
 	}
 

--- a/launcher/materialize.go
+++ b/launcher/materialize.go
@@ -1,0 +1,62 @@
+package launcher
+
+import (
+	"fmt"
+
+	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
+	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
+	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
+)
+
+// materializeTopologyLinks ensures the given (parsed) sub-topology contains a "node <-> host"
+// link stanza for every tunnel terminating on this launcher -- these stanzas are what make
+// containerlab create the host side veths that the connectivity manager later attaches the
+// tunnels to. The stanzas are launcher plumbing, so they are *not* part of the node cr config
+// (that only holds node things); they get synthesized here, into the topology file that is only
+// ever local to the launcher pod. Interfaces that already have a link in the config -- genuine
+// user defined host links, links between grouped nodes, or configs rendered by older controllers
+// that still included the synthetic host links -- are left alone.
+func materializeTopologyLinks(
+	config *clabernetesutilcontainerlab.Config,
+	tunnels []*clabernetesapisv1alpha1.PointToPointTunnel,
+) {
+	if config.Topology == nil {
+		return
+	}
+
+	linkedEndpoints := make(map[string]bool)
+
+	for _, link := range config.Topology.Links {
+		for _, endpoint := range link.Endpoints {
+			linkedEndpoints[endpoint] = true
+		}
+	}
+
+	for _, tunnel := range tunnels {
+		localEndpoint := fmt.Sprintf("%s:%s", tunnel.LocalNode, tunnel.LocalInterface)
+
+		if linkedEndpoints[localEndpoint] {
+			continue
+		}
+
+		linkedEndpoints[localEndpoint] = true
+
+		config.Topology.Links = append(
+			config.Topology.Links,
+			&clabernetesutilcontainerlab.LinkDefinition{
+				LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+					Endpoints: []string{
+						localEndpoint,
+						fmt.Sprintf(
+							"%s:%s-%s",
+							clabernetesconstants.HostKeyword,
+							tunnel.LocalNode,
+							tunnel.LocalInterface,
+						),
+					},
+					MTU: tunnel.MTU,
+				},
+			},
+		)
+	}
+}

--- a/launcher/materialize_test.go
+++ b/launcher/materialize_test.go
@@ -1,0 +1,183 @@
+package launcher //nolint:testpackage // tests cover the unexported link materializer
+
+import (
+	"reflect"
+	"testing"
+
+	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
+	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
+)
+
+func TestMaterializeTopologyLinks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		existingLinks []*clabernetesutilcontainerlab.LinkDefinition
+		tunnels       []*clabernetesapisv1alpha1.PointToPointTunnel
+		expectedLinks []*clabernetesutilcontainerlab.LinkDefinition
+	}{
+		{
+			name:          "no-tunnels",
+			existingLinks: nil,
+			tunnels:       nil,
+			expectedLinks: nil,
+		},
+		{
+			name:          "simple-tunnel",
+			existingLinks: nil,
+			tunnels: []*clabernetesapisv1alpha1.PointToPointTunnel{
+				{
+					LocalNode:      "srl1",
+					LocalInterface: "e1-1",
+					RemoteNode:     "multitool",
+				},
+			},
+			expectedLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-1", "host:srl1-e1-1"},
+					},
+				},
+			},
+		},
+		{
+			name:          "tunnel-with-mtu",
+			existingLinks: nil,
+			tunnels: []*clabernetesapisv1alpha1.PointToPointTunnel{
+				{
+					LocalNode:      "srl1",
+					LocalInterface: "e1-1",
+					RemoteNode:     "multitool",
+					MTU:            9212,
+				},
+			},
+			expectedLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-1", "host:srl1-e1-1"},
+						MTU:       9212,
+					},
+				},
+			},
+		},
+		{
+			// configs rendered by older controllers still contain the synthetic host links --
+			// those interfaces must not get a second stanza
+			name: "stanza-already-rendered",
+			existingLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-1", "host:srl1-e1-1"},
+					},
+				},
+			},
+			tunnels: []*clabernetesapisv1alpha1.PointToPointTunnel{
+				{
+					LocalNode:      "srl1",
+					LocalInterface: "e1-1",
+					RemoteNode:     "multitool",
+				},
+			},
+			expectedLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-1", "host:srl1-e1-1"},
+					},
+				},
+			},
+		},
+		{
+			// genuine user defined host links stay as they are and never get doubled up
+			name: "user-host-link-preserved",
+			existingLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-2", "host:eth1"},
+					},
+				},
+			},
+			tunnels: []*clabernetesapisv1alpha1.PointToPointTunnel{
+				{
+					LocalNode:      "srl1",
+					LocalInterface: "e1-1",
+					RemoteNode:     "multitool",
+				},
+			},
+			expectedLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-2", "host:eth1"},
+					},
+				},
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1:e1-1", "host:srl1-e1-1"},
+					},
+				},
+			},
+		},
+		{
+			// grouped nodes: tunnels can terminate on secondary nodes of the launcher too
+			name: "grouped-node-tunnels",
+			existingLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1a:e1-3", "srl1b:e1-3"},
+					},
+				},
+			},
+			tunnels: []*clabernetesapisv1alpha1.PointToPointTunnel{
+				{
+					LocalNode:      "srl1a",
+					LocalInterface: "e1-1",
+					RemoteNode:     "multitool",
+				},
+				{
+					LocalNode:      "srl1b",
+					LocalInterface: "e1-1",
+					RemoteNode:     "multitool",
+				},
+			},
+			expectedLinks: []*clabernetesutilcontainerlab.LinkDefinition{
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1a:e1-3", "srl1b:e1-3"},
+					},
+				},
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1a:e1-1", "host:srl1a-e1-1"},
+					},
+				},
+				{
+					LinkConfig: clabernetesutilcontainerlab.LinkConfig{
+						Endpoints: []string{"srl1b:e1-1", "host:srl1b-e1-1"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := &clabernetesutilcontainerlab.Config{
+				Topology: &clabernetesutilcontainerlab.Topology{
+					Links: testCase.existingLinks,
+				},
+			}
+
+			materializeTopologyLinks(config, testCase.tunnels)
+
+			if !reflect.DeepEqual(config.Topology.Links, testCase.expectedLinks) {
+				t.Fatalf(
+					"materialized links do not match expectation\ngot: %+v\nwant: %+v",
+					config.Topology.Links,
+					testCase.expectedLinks,
+				)
+			}
+		})
+	}
+}

--- a/launcher/node.go
+++ b/launcher/node.go
@@ -9,6 +9,7 @@ import (
 	clabernetesapisv1alpha1 "github.com/srl-labs/clabernetes/apis/v1alpha1"
 	clabernetesconstants "github.com/srl-labs/clabernetes/constants"
 	claberneteserrors "github.com/srl-labs/clabernetes/errors"
+	clabernetesutilcontainerlab "github.com/srl-labs/clabernetes/util/containerlab"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,11 +21,30 @@ const (
 
 // fetchNodeResource fetches "our" node cr -- the cr the clabernetes controller rendered for this
 // launcher's node -- and dumps its contents (the sub-topology, files from url, and pull secrets)
-// to disk where the rest of the launcher (and containerlab itself) expects them.
+// to disk where the rest of the launcher (and containerlab itself) expects them. The node cr
+// config only holds node things -- the link stanzas for any tunnels terminating on this launcher
+// are synthesized (from this launcher's link crs) into the written topology here.
 func (c *clabernetes) fetchNodeResource() {
 	node, err := c.getNodeResource()
 	if err != nil {
 		c.logger.Fatalf("failed fetching clabernetes node resource, err: %s", err)
+	}
+
+	config, err := clabernetesutilcontainerlab.LoadContainerlabConfig(node.Spec.Config)
+	if err != nil {
+		c.logger.Fatalf("failed parsing node resource sub-topology, err: %s", err)
+	}
+
+	c.initialTunnels, err = c.getTunnels()
+	if err != nil {
+		c.logger.Fatalf("failed listing tunnels for node, err: %s", err)
+	}
+
+	materializeTopologyLinks(config, c.initialTunnels)
+
+	configBytes, err := yaml.Marshal(config)
+	if err != nil {
+		c.logger.Fatalf("failed marshaling materialized sub-topology, err: %s", err)
 	}
 
 	filesFromURLBytes, err := yaml.Marshal(node.Spec.FilesFromURL)
@@ -38,7 +58,7 @@ func (c *clabernetes) fetchNodeResource() {
 	}
 
 	for fileName, contents := range map[string][]byte{
-		"topo.clab.yaml":               []byte(node.Spec.Config),
+		"topo.clab.yaml":               configBytes,
 		"files-from-url.yaml":          filesFromURLBytes,
 		"configured-pull-secrets.yaml": imagePullSecretsBytes,
 	} {

--- a/ui/clabernetes-openapi.json
+++ b/ui/clabernetes-openapi.json
@@ -1788,7 +1788,7 @@
                 }
             },
             "clabernetes-containerlab-dev.link.v1alpha1": {
-                "description": "Link is an object that represents a single point-to-point link between two (containerlab) nodes\nof a clabernetes Topology. Links are created and managed by the clabernetes controller -- one\nper inter-launcher link -- and hold everything both launcher pods need to establish the tunnel\n(vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big\nconnectivity object) means no single object grows with the size of the topology, which keeps\nclabernetes clear of the etcd max object size limits for very large topologies.",
+                "description": "Link is an object that represents a single point-to-point link between two (containerlab) nodes\nof a clabernetes Topology. Links are created and managed by the clabernetes controller -- one\nper inter-launcher link -- and hold everything both launcher pods need to establish the tunnel\n(vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big\nconnectivity object) means no single object grows with the size of the topology, which keeps\nclabernetes clear of the etcd max object size limits for very large topologies. The\n\"clabernetes/linkEndpointA\" and \"clabernetes/linkEndpointB\" labels hold the launcher nodes\nthat terminate each side (the primary node for grouped nodes) -- launchers select \"their\"\nlinks by those labels and derive the remote fabric service from them.",
                 "properties": {
                     "apiVersion": {
                         "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1807,16 +1807,8 @@
                             "endpointA": {
                                 "description": "EndpointA is the \"a\" side of this link.",
                                 "properties": {
-                                    "destination": {
-                                        "description": "Destination is the qualified kubernetes service name over which this side of the link can\nbe reached (that is, the service the *other* side of the link connects to).",
-                                        "type": "string"
-                                    },
                                     "interfaceName": {
                                         "description": "InterfaceName is the name of the interface on the node this side of the link is on.",
-                                        "type": "string"
-                                    },
-                                    "launcherNode": {
-                                        "description": "LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side\nof the link -- for \"grouped\" nodes this is the primary node of the group, otherwise this is\nsimply the same as NodeName.",
                                         "type": "string"
                                     },
                                     "nodeName": {
@@ -1825,9 +1817,7 @@
                                     }
                                 },
                                 "required": [
-                                    "destination",
                                     "interfaceName",
-                                    "launcherNode",
                                     "nodeName"
                                 ],
                                 "type": "object"
@@ -1835,16 +1825,8 @@
                             "endpointB": {
                                 "description": "EndpointB is the \"b\" side of this link.",
                                 "properties": {
-                                    "destination": {
-                                        "description": "Destination is the qualified kubernetes service name over which this side of the link can\nbe reached (that is, the service the *other* side of the link connects to).",
-                                        "type": "string"
-                                    },
                                     "interfaceName": {
                                         "description": "InterfaceName is the name of the interface on the node this side of the link is on.",
-                                        "type": "string"
-                                    },
-                                    "launcherNode": {
-                                        "description": "LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side\nof the link -- for \"grouped\" nodes this is the primary node of the group, otherwise this is\nsimply the same as NodeName.",
                                         "type": "string"
                                     },
                                     "nodeName": {
@@ -1853,9 +1835,7 @@
                                     }
                                 },
                                 "required": [
-                                    "destination",
                                     "interfaceName",
-                                    "launcherNode",
                                     "nodeName"
                                 ],
                                 "type": "object"

--- a/ui/clabernetes-openapi.json
+++ b/ui/clabernetes-openapi.json
@@ -1860,6 +1860,10 @@
                                 ],
                                 "type": "object"
                             },
+                            "mtu": {
+                                "description": "MTU is the mtu for the link as set in the original topology definition -- launchers apply\nthis to the (node side of the) link termination they create; zero means \"unset\" (use the\ncontainerlab default).",
+                                "type": "integer"
+                            },
                             "topologyName": {
                                 "description": "TopologyName is the name of the Topology this Link belongs to.",
                                 "type": "string"

--- a/ui/clabernetes-openapi.json
+++ b/ui/clabernetes-openapi.json
@@ -1802,7 +1802,7 @@
                         "type": "object"
                     },
                     "spec": {
-                        "description": "LinkSpec is the spec for a Link resource.",
+                        "description": "LinkSpec is the spec for a Link resource. It holds only the \"wire as the user drew it\" --\nanything operational (like the allocated tunnel id) lives in the status or is derived by the\nlaunchers.",
                         "properties": {
                             "endpointA": {
                                 "description": "EndpointA is the \"a\" side of this link.",
@@ -1847,24 +1847,25 @@
                             "topologyName": {
                                 "description": "TopologyName is the name of the Topology this Link belongs to.",
                                 "type": "string"
-                            },
-                            "tunnelID": {
-                                "description": "TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of\nthe link use the same id.",
-                                "maximum": 16000000,
-                                "minimum": 1,
-                                "type": "integer"
                             }
                         },
                         "required": [
                             "endpointA",
                             "endpointB",
-                            "topologyName",
-                            "tunnelID"
+                            "topologyName"
                         ],
                         "type": "object"
                     },
                     "status": {
                         "description": "LinkStatus is the status for a Link resource.",
+                        "properties": {
+                            "tunnelID": {
+                                "description": "TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for\nthis link -- both sides of the link use the same id. This is an allocation rather than user\nintent, hence it living in the status; zero means \"not allocated yet\" (launchers skip such\nlinks until the controller has filled the id in).",
+                                "maximum": 16000000,
+                                "minimum": 0,
+                                "type": "integer"
+                            }
+                        },
                         "type": "object"
                     }
                 },

--- a/ui/src/lib/clabernetes-client/types.gen.ts
+++ b/ui/src/lib/clabernetes-client/types.gen.ts
@@ -1619,7 +1619,10 @@ export type ClabernetesContainerlabDevTopologyListV1Alpha1 = {
  * per inter-launcher link -- and hold everything both launcher pods need to establish the tunnel
  * (vxlan or slurpeeth) for the link. Storing this data per-link (rather than in one big
  * connectivity object) means no single object grows with the size of the topology, which keeps
- * clabernetes clear of the etcd max object size limits for very large topologies.
+ * clabernetes clear of the etcd max object size limits for very large topologies. The
+ * "clabernetes/linkEndpointA" and "clabernetes/linkEndpointB" labels hold the launcher nodes
+ * that terminate each side (the primary node for grouped nodes) -- launchers select "their"
+ * links by those labels and derive the remote fabric service from them.
  */
 export type ClabernetesContainerlabDevLinkV1Alpha1 = {
     /**
@@ -1649,20 +1652,9 @@ export type ClabernetesContainerlabDevLinkV1Alpha1 = {
          */
         endpointA: {
             /**
-             * Destination is the qualified kubernetes service name over which this side of the link can
-             * be reached (that is, the service the *other* side of the link connects to).
-             */
-            destination: string;
-            /**
              * InterfaceName is the name of the interface on the node this side of the link is on.
              */
             interfaceName: string;
-            /**
-             * LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-             * of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-             * simply the same as NodeName.
-             */
-            launcherNode: string;
             /**
              * NodeName is the name of the (containerlab) node this side of the link resides on.
              */
@@ -1673,20 +1665,9 @@ export type ClabernetesContainerlabDevLinkV1Alpha1 = {
          */
         endpointB: {
             /**
-             * Destination is the qualified kubernetes service name over which this side of the link can
-             * be reached (that is, the service the *other* side of the link connects to).
-             */
-            destination: string;
-            /**
              * InterfaceName is the name of the interface on the node this side of the link is on.
              */
             interfaceName: string;
-            /**
-             * LauncherNode is the name of the (containerlab) node whose launcher pod terminates this side
-             * of the link -- for "grouped" nodes this is the primary node of the group, otherwise this is
-             * simply the same as NodeName.
-             */
-            launcherNode: string;
             /**
              * NodeName is the name of the (containerlab) node this side of the link resides on.
              */

--- a/ui/src/lib/clabernetes-client/types.gen.ts
+++ b/ui/src/lib/clabernetes-client/types.gen.ts
@@ -1693,6 +1693,12 @@ export type ClabernetesContainerlabDevLinkV1Alpha1 = {
             nodeName: string;
         };
         /**
+         * MTU is the mtu for the link as set in the original topology definition -- launchers apply
+         * this to the (node side of the) link termination they create; zero means "unset" (use the
+         * containerlab default).
+         */
+        mtu?: number;
+        /**
          * TopologyName is the name of the Topology this Link belongs to.
          */
         topologyName: string;

--- a/ui/src/lib/clabernetes-client/types.gen.ts
+++ b/ui/src/lib/clabernetes-client/types.gen.ts
@@ -1644,7 +1644,9 @@ export type ClabernetesContainerlabDevLinkV1Alpha1 = {
         [key: string]: unknown;
     };
     /**
-     * LinkSpec is the spec for a Link resource.
+     * LinkSpec is the spec for a Link resource. It holds only the "wire as the user drew it" --
+     * anything operational (like the allocated tunnel id) lives in the status or is derived by the
+     * launchers.
      */
     spec?: {
         /**
@@ -1683,17 +1685,18 @@ export type ClabernetesContainerlabDevLinkV1Alpha1 = {
          * TopologyName is the name of the Topology this Link belongs to.
          */
         topologyName: string;
-        /**
-         * TunnelID is the id number of the tunnel (vnid or segment id) for this link -- both sides of
-         * the link use the same id.
-         */
-        tunnelID: number;
     };
     /**
      * LinkStatus is the status for a Link resource.
      */
     status?: {
-        [key: string]: unknown;
+        /**
+         * TunnelID is the id number of the tunnel (vnid or segment id) the controller allocated for
+         * this link -- both sides of the link use the same id. This is an allocation rather than user
+         * intent, hence it living in the status; zero means "not allocated yet" (launchers skip such
+         * links until the controller has filled the id in).
+         */
+        tunnelID?: number;
     };
 };
 

--- a/ui/src/lib/kubernetes-visualize.ts
+++ b/ui/src/lib/kubernetes-visualize.ts
@@ -147,9 +147,14 @@ export async function visualizeTopology(namespace: string, name: string): Promis
       continue;
     }
 
-    const aFabricService = `svc/${endpointA.launcherNode}-vx`;
+    // the launcher nodes terminating each side of the link live on the link's endpoint labels
+    const linkLabels = link.metadata?.labels ?? {};
+    const aLauncherNode = linkLabels["clabernetes/linkEndpointA"] ?? endpointA.nodeName;
+    const bLauncherNode = linkLabels["clabernetes/linkEndpointB"] ?? endpointB.nodeName;
+
+    const aFabricService = `svc/${aLauncherNode}-vx`;
     const aInterface = `${endpointA.nodeName}-${endpointA.interfaceName}`;
-    const bFabricService = `svc/${endpointB.launcherNode}-vx`;
+    const bFabricService = `svc/${bLauncherNode}-vx`;
     const bInterface = `${endpointB.nodeName}-${endpointB.interfaceName}`;
 
     nodes.push({

--- a/ui/src/lib/kubernetes-visualize.ts
+++ b/ui/src/lib/kubernetes-visualize.ts
@@ -1,5 +1,5 @@
 "use server";
-import type {Edge} from "@xyflow/react";
+import { listClabernetesContainerlabDevV1Alpha1NamespacedLink } from "@/lib/clabernetes-client";
 import {
   AppsV1Api,
   CoreV1Api,
@@ -7,9 +7,7 @@ import {
   type V1DeploymentList,
   type V1ServiceList,
 } from "@kubernetes/client-node";
-import {
-  listClabernetesContainerlabDevV1Alpha1NamespacedLink
-} from "@/lib/clabernetes-client";
+import type { Edge } from "@xyflow/react";
 
 async function deploymentsByOwner(
   namespace: string,
@@ -21,11 +19,11 @@ async function deploymentsByOwner(
   kc.loadFromDefault();
 
   return await kc
-      .makeApiClient(AppsV1Api)
-      .listNamespacedDeployment({namespace: namespace, labelSelector: labelSelector})
-      .catch((error: unknown) => {
-        throw error;
-      });
+    .makeApiClient(AppsV1Api)
+    .listNamespacedDeployment({ namespace: namespace, labelSelector: labelSelector })
+    .catch((error: unknown) => {
+      throw error;
+    });
 }
 
 async function servicesByOwner(
@@ -38,11 +36,11 @@ async function servicesByOwner(
   kc.loadFromDefault();
 
   return await kc
-      .makeApiClient(CoreV1Api)
-      .listNamespacedService({namespace: namespace, labelSelector: labelSelector})
-      .catch((error: unknown) => {
-        throw error;
-      });
+    .makeApiClient(CoreV1Api)
+    .listNamespacedService({ namespace: namespace, labelSelector: labelSelector })
+    .catch((error: unknown) => {
+      throw error;
+    });
 }
 
 export interface VisualizeObject {
@@ -148,7 +146,7 @@ export async function visualizeTopology(namespace: string, name: string): Promis
     }
 
     // the launcher nodes terminating each side of the link live on the link's endpoint labels
-    const linkLabels = link.metadata?.labels ?? {};
+    const linkLabels = (link.metadata?.labels ?? {}) as Record<string, string | undefined>;
     const aLauncherNode = linkLabels["clabernetes/linkEndpointA"] ?? endpointA.nodeName;
     const bLauncherNode = linkLabels["clabernetes/linkEndpointB"] ?? endpointB.nodeName;
 


### PR DESCRIPTION
## What

Follow-up to the Node/Link CR split: make the Link CR the single authoritative representation of every cross-launcher link, and keep the launcher plumbing that realizes those links out of the persisted API.

Before this change one logical link was persisted three times:

| Where | Content |
|---|---|
| `srl1`'s Node config | `srl1:e1-1 <-> host:srl1-e1-1` (synthetic) |
| `multitool`'s Node config | `multitool:eth1 <-> host:multitool-eth1` (synthetic) |
| The Link CR | `srl1:e1-1 <-> multitool:eth1` |

The synthetic `host:` stanzas exist only so containerlab creates the host-side veths that the vxlan/slurpeeth tunnels attach to -- that is launcher plumbing, not API. Persisting it meant Node objects grew with link degree, link changes rewrote (and rebooted) Nodes, and the UI/users saw implementation details in `kubectl get`.

## How

- **Controller** no longer renders synthetic host link stanzas into per-node sub-topologies (containerlab and kne definitions). Node configs keep only node-local links: user-defined `host:` links (now preserving their mtu/labels/vars instead of dropping them) and links between grouped nodes.
- **Launcher** synthesizes the `node <-> host` stanzas into the `topo.clab.yaml` it deploys, from the same Link CR list that seeds the connectivity manager (one snapshot for both, so deployed veths and initial tunnels always line up). Interfaces that already have a stanza are skipped, so configs rendered by older controllers keep working.
- **Link CRs carry `mtu`** from the original topology link definition; launchers apply it to the stanza they synthesize. Previously the value was silently dropped.
- **The tunnel id lives in `status`, not `spec`.** It is an allocation the controller makes (unique per topology, stable across reconciles), not user intent -- so the spec stays purely "the wire as the user drew it". Launchers read `status.tunnelID` and skip links whose id has not been allocated yet, which is exactly the contract a future "user creates Link CRs directly" model needs: spec in, controller stamps everything else (labels, tunnel id, owner refs).
- **Link endpoints are just `nodeName` + `interfaceName`.** The per-endpoint `destination` (a full in-cluster DNS name) and `launcherNode` are no longer persisted: launchers derive the remote fabric service (`<topology>-<launcherNode>-vx.<ns>.<suffix>`) from the topology name and the remote launcher node held in the already-load-bearing `clabernetes/linkEndpointA`/`B` labels, with the topology-prefix and DNS-suffix knobs passed down via two new launcher env vars (`LAUNCHER_TOPOLOGY_REMOVE_PREFIX`, `LAUNCHER_IN_CLUSTER_DNS_SUFFIX`). The controller no longer computes destinations at all.
- **Deployments carry a link-attachments digest** (pod template annotation, hash of local node/interface/mtu set). Adding or removing a link rolls the pod so the topology is redeployed with the right veths; remote-side-only changes (rewires) leave the digest -- and the pod, and the NOS -- alone and are handled live by the launcher's link watch. Restart detection deep-compares the remaining (node-local) links, since nothing watches those at runtime.

## Result

```yaml
# Node CR: node things only
spec:
  config: |
    name: clabernetes-srl1
    topology:
        nodes:
            srl1:
                kind: nokia_srlinux
                image: ghcr.io/nokia/srlinux:26.3
        # no links section

# Link CR: the wire, once, in the user's terms
metadata:
  labels:
    clabernetes/linkEndpointA: srl1        # launcher terminating each side
    clabernetes/linkEndpointB: multitool   # (differs from nodeName only for grouped nodes)
spec:                                      # only the wire as the user drew it
  endpointA: {nodeName: srl1, interfaceName: e1-1}
  endpointB: {nodeName: multitool, interfaceName: eth1}
status:
  tunnelID: 1                              # allocated by the controller
```

- Node objects no longer grow with link degree (only with launcher group size).
- Rewiring a link no longer reboots the NOS.
- Link attributes survive onto the wire.

## Upgrades

Self-healing: existing Node configs still contain the old synthetic stanzas, so they differ from the fresh render, which reboots the launchers onto the new links-free configs (with the new launcher image doing the materialization). Rollback works because the launcher skips synthesizing stanzas that are already present in the config.

## Testing

- Unit tests + regenerated goldens (`go test ./...`, lint clean).
- New unit tests: launcher link materializer (old-config compatibility, user host links, grouped nodes, mtu) and link-to-tunnel conversion (side selection via labels, prefix/suffix destination derivation).
- Full local e2e flow: kind cluster, locally built manager/launcher/ui images, basic + clabverter suites green (goldens regenerated: Node configs lose the links section, deployments gain the digest annotation and the two derivation env vars, Link CRs slim down).
- Real-lab validation on a `try-c9s` cluster including a genuine **0.6.0 in-place upgrade**: started from the published 0.6.0 chart (topology ConfigMap + Connectivity CR era), upgraded to this branch — Node/Link CRs created, legacy resources cleaned up, launchers rolled, dataplane (ping across the vxlan tunnel) and SSH/gNMI via the MetalLB VIP verified before and after. Link-CR delete/recreate re-established the tunnel with the same tunnel ID and zero pod restarts.

Note for release notes: upgrades need `kubectl apply -f charts/clabernetes/crds/` alongside the chart upgrade (helm does not update CRDs from `crds/` on upgrade).
