### PR TITLE
latest dlv requires go >= 1.25

### DIFF
--- a/.develop/dev.Dockerfile
+++ b/.develop/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.24-bookworm
+FROM --platform=linux/amd64 golang:1.26-bookworm
 
 RUN apt-get update -y && \
     apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
build:clabernetes-dev  > [3/7] RUN go install github.com/go-delve/delve/cmd/dlv@latest: build:clabernetes-dev 0.438 go: downloading github.com/go-delve/delve v1.27.0 build:clabernetes-dev 0.895 go: github.com/go-delve/delve/cmd/dlv@latest: github.com/go-delve/delve@v1.27.0 requires go >= 1.25 (running go 1.24.13; GOTOOLCHAIN=local) build:clabernetes-dev ------
build:clabernetes-dev
build:clabernetes-dev  1 warning found (use docker --debug to expand): build:clabernetes-dev  - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 1) build:clabernetes-dev .develop/dev.Dockerfile:15
build:clabernetes-dev --------------------
build:clabernetes-dev   13 |         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archive/*.deb
build:clabernetes-dev   14 |
build:clabernetes-dev   15 | >>> RUN go install github.com/go-delve/delve/cmd/dlv@latest
build:clabernetes-dev   16 |
build:clabernetes-dev   17 |     WORKDIR /clabernetes
build:clabernetes-dev --------------------
build:clabernetes-dev ERROR: failed to build: failed to solve: process "/bin/sh -c go install github.com/go-delve/delve/cmd/dlv@latest" did not complete successfully: exit code: 1
build_images: build images: error building image ghcr.io/srl-labs/clabernetes/clabernetes-manager-dev:2a20f1a1: error executing 'docker buildx build --tag ghcr.io/srl-labs/clabernetes/clabernetes-manager-dev:2a20f1a1 --push --file .develop/dev.Dockerfile -':
fatal exit status 1